### PR TITLE
Add modular service handlers

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,52 @@
+import fetch from 'node-fetch';
+import UserAgent from 'user-agents';
+
+export const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': '*',
+};
+
+const DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY;
+
+export function createService(baseUrl, allowedPaths) {
+  return async function(req, res, next) {
+    if (!allowedPaths.has(req.path)) {
+      return next();
+    }
+
+    if (!DATAGOKR_SERVICEKEY) {
+      return res.status(500).json({
+        error: 'Missing environment variable',
+        message: 'DATAGOKR_SERVICEKEY is not defined in the environment'
+      });
+    }
+
+    const params = new URLSearchParams(req.query);
+    params.set('serviceKey', DATAGOKR_SERVICEKEY);
+    const targetUrl = `${baseUrl}${req.path}?${params.toString()}`;
+
+    const randomUserAgent = new UserAgent().toString();
+
+    try {
+      const response = await fetch(targetUrl, {
+        method: 'GET',
+        headers: { 'User-Agent': randomUserAgent },
+        timeout: 2000,
+      });
+
+      res.set({
+        'Content-Type': response.headers.get('content-type') || 'application/xml',
+        ...CORS_HEADERS,
+      });
+
+      response.body.pipe(res);
+    } catch (e) {
+      console.error('Fetch Error:', e);
+      res.status(500).json({
+        error: 'Fetch Error',
+        message: e.message,
+      });
+    }
+  };
+}

--- a/src/common.js
+++ b/src/common.js
@@ -1,51 +1,64 @@
-import fetch from 'node-fetch';
-import UserAgent from 'user-agents';
+import fetch from "node-fetch";
+import UserAgent from "user-agents";
 
 export const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': '*',
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "*",
 };
 
 const DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY;
+if (!DATAGOKR_SERVICEKEY) {
+  console.error(
+    "FATAL ERROR: DATAGOKR_SERVICEKEY is not defined in the environment."
+  );
+  process.exit(1);
+}
 
 export function createService(baseUrl, allowedPaths) {
-  return async function(req, res, next) {
+  return async function (req, res, next) {
     if (!allowedPaths.has(req.path)) {
       return next();
     }
 
-    if (!DATAGOKR_SERVICEKEY) {
-      return res.status(500).json({
-        error: 'Missing environment variable',
-        message: 'DATAGOKR_SERVICEKEY is not defined in the environment'
-      });
-    }
-
     const params = new URLSearchParams(req.query);
-    params.set('serviceKey', DATAGOKR_SERVICEKEY);
+    params.set("serviceKey", DATAGOKR_SERVICEKEY);
     const targetUrl = `${baseUrl}${req.path}?${params.toString()}`;
 
     const randomUserAgent = new UserAgent().toString();
 
     try {
       const response = await fetch(targetUrl, {
-        method: 'GET',
-        headers: { 'User-Agent': randomUserAgent },
+        method: "GET",
+        headers: { "User-Agent": randomUserAgent },
         timeout: 2000,
       });
 
       res.set({
-        'Content-Type': response.headers.get('content-type') || 'application/xml',
+        "Content-Type":
+          response.headers.get("content-type") || "application/xml",
         ...CORS_HEADERS,
       });
 
-      response.body.pipe(res);
+      const stream = response.body.pipe(res);
+      stream.on("error", (err) => {
+        console.error("Pipe Error:", err);
+        // End response on pipe error to avoid hanging
+        if (!res.headersSent) {
+          res.status(500).end();
+        } else {
+          res.end();
+        }
+      });
     } catch (e) {
-      console.error('Fetch Error:', e);
+      // Log detailed error internally
+      console.error("Fetch Error:", e);
+      const isTimeoutError = e.name === "AbortError";
       res.status(500).json({
-        error: 'Fetch Error',
-        message: e.message,
+        error: isTimeoutError ? "Request Timeout" : "Service Unavailable",
+        message: isTimeoutError
+          ? "Request timed out"
+          : "Unable to process request",
       });
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,34 @@
-import express from 'express';
-import { CORS_HEADERS } from './common.js';
-import createSpcdeInfoService from './services/spcdeInfoService.js';
-import createSecuritiesProductInfoService from './services/getSecuritiesProductInfoService.js';
+import express from "express";
+import { CORS_HEADERS } from "./common.js";
+import createSpcdeInfoService from "./services/spcdeInfoService.js";
+import createSecuritiesProductInfoService from "./services/getSecuritiesProductInfoService.js";
+import crypto from "crypto";
 
 const AUTH_API_KEY = process.env.AUTH_API_KEY;
+if (!AUTH_API_KEY) {
+  console.error("Error: Missing required environment variable AUTH_API_KEY");
+  process.exit(1);
+}
 
 const app = express();
 
 app.use((req, res, next) => {
-  if (req.method === 'OPTIONS') {
+  if (req.method === "OPTIONS") {
     return res.set(CORS_HEADERS).status(204).send();
   }
 
-  const clientApiKey = req.header('x-api-key');
-  if (!clientApiKey || clientApiKey !== AUTH_API_KEY) {
+  const clientApiKey = req.header("x-api-key");
+  // Constant-time API key comparison to mitigate timing attacks
+  const clientKey = Buffer.from(clientApiKey || "", "utf8");
+  const authKey = Buffer.from(AUTH_API_KEY, "utf8");
+  if (
+    !clientApiKey ||
+    clientKey.length !== authKey.length ||
+    !crypto.timingSafeEqual(clientKey, authKey)
+  ) {
     return res.status(401).json({
-      error: 'Unauthorized',
-      message: 'Invalid or missing x-api-key header'
+      error: "Unauthorized",
+      message: "Invalid or missing x-api-key header",
     });
   }
 
@@ -27,7 +39,7 @@ app.use(createSpcdeInfoService());
 app.use(createSecuritiesProductInfoService());
 
 app.use((req, res) => {
-  res.status(404).send('Not Found');
+  res.status(404).send("Not Found");
 });
 
 const PORT = process.env.PORT || 3000;

--- a/src/index.js
+++ b/src/index.js
@@ -1,81 +1,33 @@
-import express from "express";
-import fetch from "node-fetch";
-import UserAgent from "user-agents";
-
-// 재사용 가능한 CORS 헤더 설정
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': '*',
-};
+import express from 'express';
+import { CORS_HEADERS } from './common.js';
+import createSpcdeInfoService from './services/spcdeInfoService.js';
+import createSecuritiesProductInfoService from './services/getSecuritiesProductInfoService.js';
 
 const AUTH_API_KEY = process.env.AUTH_API_KEY;
-const DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY;
 
 const app = express();
-const BASE_URL = "https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService";
 
-const allowedPaths = new Set(["/getRestDeInfo", "/getAnniversaryInfo", "/get24DivisionsInfo"]);
-
-app.use(async (req, res) => {
-  // CORS preflight handling
+app.use((req, res, next) => {
   if (req.method === 'OPTIONS') {
     return res.set(CORS_HEADERS).status(204).send();
   }
 
-  // 인증용 API 키 검증
   const clientApiKey = req.header('x-api-key');
   if (!clientApiKey || clientApiKey !== AUTH_API_KEY) {
     return res.status(401).json({
-      error: "Unauthorized",
-      message: "Invalid or missing x-api-key header"
+      error: 'Unauthorized',
+      message: 'Invalid or missing x-api-key header'
     });
   }
 
-  // 공공데이터 포털 서비스 키 존재 확인 
-  if (!DATAGOKR_SERVICEKEY) {
-    return res.status(500).json({
-      error: "Missing environment variable",
-      message: "DATAGOKR_SERVICEKEY is not defined in the environment"
-    });
-  }
-  
-  // 요청 가능 주소 확인
-  const urlPath = req.path;
-  if (!allowedPaths.has(urlPath)) {
-    return res.status(404).send("Not Found");
-  }
+  next();
+});
 
-  // 쿼리에 서비스 키 추가
-  const params = new URLSearchParams(req.query);
-  params.set("serviceKey", DATAGOKR_SERVICEKEY);
-  const targetUrl = `${BASE_URL}${urlPath}?${params.toString()}`;
+app.use(createSpcdeInfoService());
+app.use(createSecuritiesProductInfoService());
 
-  // 임의 userAgent 생성
-  const randomUserAgent = new UserAgent().toString();
-
-  try {
-    const response = await fetch(targetUrl, {
-      method: "GET",
-      headers: {
-        'User-Agent': randomUserAgent
-      },
-      timeout: 2000,
-    });
-
-    res.set({
-      'Content-Type': response.headers.get('content-type') || 'application/xml',
-      ...CORS_HEADERS,
-    });
-
-    response.body.pipe(res);
-  } catch (e) {
-    console.error("Fetch Error:", e);
-    res.status(500).json({
-      error: "Fetch Error",
-      message: e.message
-    });
-  }
+app.use((req, res) => {
+  res.status(404).send('Not Found');
 });
 
 const PORT = process.env.PORT || 3000;

--- a/src/services/getSecuritiesProductInfoService.js
+++ b/src/services/getSecuritiesProductInfoService.js
@@ -1,0 +1,7 @@
+import { createService } from '../common.js';
+
+export default function createSecuritiesProductInfoService() {
+  const baseUrl = 'https://apis.data.go.kr/1160100/service/GetSecuritiesProductInfoService';
+  const allowedPaths = new Set(['/getETFPriceInfo', '/getETNPriceInfo', '/getELWPriceInfo']);
+  return createService(baseUrl, allowedPaths);
+}

--- a/src/services/spcdeInfoService.js
+++ b/src/services/spcdeInfoService.js
@@ -1,0 +1,7 @@
+import { createService } from '../common.js';
+
+export default function createSpcdeInfoService() {
+  const baseUrl = 'https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService';
+  const allowedPaths = new Set(['/getRestDeInfo', '/getAnniversaryInfo', '/get24DivisionsInfo']);
+  return createService(baseUrl, allowedPaths);
+}


### PR DESCRIPTION
## Summary
- add a common proxy handler module
- split SpcdeInfoService and GetSecuritiesProductInfoService into separate modules
- update server to use the new service modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a2c9d521c832990d78f9a38458596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for proxying requests to government open APIs for special date and securities product information.
  - Introduced improved handling of CORS headers for all relevant API responses.

- **Refactor**
  - Streamlined the app’s internal structure by modularizing service logic and simplifying route handling for better maintainability.

- **Bug Fixes**
  - Enhanced error handling for missing API keys and external API failures, providing clearer error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->