### PR TITLE
Add unit tests for core services and plan JS→TS migration

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -2,9 +2,41 @@
 
 > 기존 서비스(spcdeInfoService, getSecuritiesProductInfoService)와 핵심 프록시 로직(common.js)에 대한 테스트 커버리지 확보.
 
-- [ ] common.js createService — 허용된 경로 요청 시 프록시 동작 확인
-- [ ] common.js createService — 허용되지 않은 경로 요청 시 next() 호출 확인
-- [ ] common.js createService — 타임아웃 시 적절한 에러 응답 확인
-- [ ] common.js createService — fetch 실패 시 에러 응답 확인
-- [ ] spcdeInfoService — 허용 경로 목록 및 서비스 생성 확인
-- [ ] getSecuritiesProductInfoService — 허용 경로 목록 및 서비스 생성 확인
+- [x] common.js createService — 허용된 경로 요청 시 프록시 동작 확인
+- [x] common.js createService — 허용되지 않은 경로 요청 시 next() 호출 확인
+- [x] common.js createService — 타임아웃 시 적절한 에러 응답 확인
+- [x] common.js createService — fetch 실패 시 에러 응답 확인
+- [x] spcdeInfoService — 허용 경로 목록 및 서비스 생성 확인
+- [x] getSecuritiesProductInfoService — 허용 경로 목록 및 서비스 생성 확인
+
+## JS → TS 변환
+
+> JavaScript 프로젝트를 TypeScript로 변환하여 타입 안전성을 확보한다. 기존 동작은 그대로 유지한다.
+
+### 인프라 설정
+
+- [ ] typescript, @types/express, @types/node devDependencies 추가 및 설치
+- [ ] tsconfig.json 생성 (ESM, NodeNext, outDir: dist, strict)
+- [ ] package.json 수정 — start 스크립트를 `node dist/index.js`로, lint-staged glob을 `*.{ts,json}`으로 변경
+- [ ] vitest.config.js → vitest.config.ts 변환
+- [ ] biome.json에 TypeScript 포함 확인 (기본 지원이므로 변경 불필요할 수 있음)
+
+### 소스 파일 변환
+
+- [ ] src/common.js → src/common.ts (타입 추가: Request, Response, NextFunction, 반환 타입 명시)
+- [ ] src/services/spcdeInfoService.js → src/services/spcdeInfoService.ts
+- [ ] src/services/getSecuritiesProductInfoService.js → src/services/getSecuritiesProductInfoService.ts
+- [ ] src/services/bidPublicInfoService.js → src/services/bidPublicInfoService.ts
+- [ ] src/index.js → src/index.ts (import 경로에서 .js 확장자 조정)
+
+### 테스트 변환
+
+- [ ] src/services/bidPublicInfoService.test.js → src/services/bidPublicInfoService.test.ts (import 경로, mock 타입 조정)
+
+### 빌드 & 배포
+
+- [ ] Dockerfile 수정 — 빌드 스테이지 추가 (npm run build 후 dist/ 만 복사)
+- [ ] npm run build (tsc) 스크립트 추가 및 빌드 확인
+- [ ] 전체 테스트 통과 확인
+- [ ] 전체 lint 통과 확인
+- [ ] 기존 .js 소스 파일 삭제

--- a/src/common.test.js
+++ b/src/common.test.js
@@ -1,8 +1,7 @@
 import { PassThrough } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-process.env.DATAGOKR_SERVICEKEY =
-  process.env.DATAGOKR_SERVICEKEY || "test-service-key";
+process.env.DATAGOKR_SERVICEKEY = "test-service-key";
 
 vi.mock("node-fetch", () => ({
   default: vi.fn(),
@@ -28,6 +27,10 @@ function createMockRes() {
 }
 
 describe("createService", () => {
+  beforeEach(() => {
+    fetch.mockReset();
+  });
+
   it("proxies request for an allowed path with correct URL, headers, and streaming", async () => {
     const responseBody = new PassThrough();
     fetch.mockResolvedValueOnce({
@@ -68,7 +71,6 @@ describe("createService", () => {
   });
 
   it("calls next() and does not fetch for disallowed paths", async () => {
-    fetch.mockClear();
     const middleware = createService(
       "https://api.example.com",
       new Set(["/allowed"]),

--- a/src/common.test.js
+++ b/src/common.test.js
@@ -1,0 +1,127 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+process.env.DATAGOKR_SERVICEKEY =
+  process.env.DATAGOKR_SERVICEKEY || "test-service-key";
+
+vi.mock("node-fetch", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("user-agents", () => ({
+  default: class {
+    toString() {
+      return "mock-user-agent";
+    }
+  },
+}));
+
+const { default: fetch } = await import("node-fetch");
+const { createService } = await import("./common.js");
+
+function createMockRes() {
+  const res = new PassThrough();
+  res.set = vi.fn();
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn();
+  return res;
+}
+
+describe("createService", () => {
+  it("proxies request for an allowed path with correct URL, headers, and streaming", async () => {
+    const responseBody = new PassThrough();
+    fetch.mockResolvedValueOnce({
+      headers: {
+        get: (name) => (name === "content-type" ? "application/xml" : null),
+      },
+      body: responseBody,
+    });
+
+    const baseUrl = "https://api.example.com";
+    const allowedPaths = new Set(["/getAllowed"]);
+    const middleware = createService(baseUrl, allowedPaths);
+
+    const req = { path: "/getAllowed", query: { numOfRows: "10" } };
+    const res = createMockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledOnce();
+
+    const calledUrl = fetch.mock.calls[0][0];
+    expect(calledUrl).toContain("https://api.example.com/getAllowed?");
+    expect(calledUrl).toContain("numOfRows=10");
+    expect(calledUrl).toContain("serviceKey=test-service-key");
+
+    const calledOptions = fetch.mock.calls[0][1];
+    expect(calledOptions.method).toBe("GET");
+    expect(calledOptions.headers["User-Agent"]).toBe("mock-user-agent");
+
+    expect(res.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "Content-Type": "application/xml",
+        "Access-Control-Allow-Origin": "*",
+      }),
+    );
+  });
+
+  it("calls next() and does not fetch for disallowed paths", async () => {
+    fetch.mockClear();
+    const middleware = createService(
+      "https://api.example.com",
+      new Set(["/allowed"]),
+    );
+
+    const req = { path: "/notAllowed", query: {} };
+    const res = createMockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("responds with 500 and timeout message on AbortError", async () => {
+    const abortError = new DOMException("signal timed out", "AbortError");
+    fetch.mockRejectedValueOnce(abortError);
+
+    const middleware = createService(
+      "https://api.example.com",
+      new Set(["/path"]),
+    );
+    const req = { path: "/path", query: {} };
+    const res = createMockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Request Timeout",
+      message: "Request timed out",
+    });
+  });
+
+  it("responds with 500 and service unavailable on generic fetch error", async () => {
+    fetch.mockRejectedValueOnce(new Error("network failure"));
+
+    const middleware = createService(
+      "https://api.example.com",
+      new Set(["/path"]),
+    );
+    const req = { path: "/path", query: {} };
+    const res = createMockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Service Unavailable",
+      message: "Unable to process request",
+    });
+  });
+});

--- a/src/services/getSecuritiesProductInfoService.test.js
+++ b/src/services/getSecuritiesProductInfoService.test.js
@@ -1,0 +1,80 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+process.env.DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY || "test-key";
+
+vi.mock("node-fetch", () => ({
+  default: vi.fn(() =>
+    Promise.resolve({
+      headers: { get: () => "application/xml" },
+      body: new PassThrough(),
+    }),
+  ),
+}));
+
+vi.mock("user-agents", () => ({
+  default: class {
+    toString() {
+      return "test-agent";
+    }
+  },
+}));
+
+const { default: createSecuritiesProductInfoService } = await import(
+  "./getSecuritiesProductInfoService.js"
+);
+
+const ALLOWED_PATHS = [
+  "/getETFPriceInfo",
+  "/getETNPriceInfo",
+  "/getELWPriceInfo",
+];
+
+function createMockRes() {
+  const res = new PassThrough();
+  res.set = vi.fn();
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn();
+  return res;
+}
+
+describe("createSecuritiesProductInfoService", () => {
+  it("returns a middleware function", () => {
+    const middleware = createSecuritiesProductInfoService();
+    expect(typeof middleware).toBe("function");
+  });
+
+  it("calls next for disallowed paths", async () => {
+    const middleware = createSecuritiesProductInfoService();
+    const next = vi.fn();
+
+    await middleware({ path: "/notAllowed", query: {} }, createMockRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("does not call next for allowed paths", async () => {
+    const middleware = createSecuritiesProductInfoService();
+    const next = vi.fn();
+
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      await middleware({ path, query: {} }, createMockRes(), next);
+      expect(next).not.toHaveBeenCalled();
+    }
+  });
+
+  it("has exactly 3 allowed endpoints", async () => {
+    const middleware = createSecuritiesProductInfoService();
+    const next = vi.fn();
+
+    let acceptedCount = 0;
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      await middleware({ path, query: {} }, createMockRes(), next);
+      if (!next.mock.calls.length) acceptedCount++;
+    }
+
+    expect(acceptedCount).toBe(3);
+    expect(ALLOWED_PATHS).toHaveLength(3);
+  });
+});

--- a/src/services/getSecuritiesProductInfoService.test.js
+++ b/src/services/getSecuritiesProductInfoService.test.js
@@ -1,7 +1,7 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
-process.env.DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY || "test-key";
+process.env.DATAGOKR_SERVICEKEY = "test-key";
 
 vi.mock("node-fetch", () => ({
   default: vi.fn(() =>
@@ -61,20 +61,5 @@ describe("createSecuritiesProductInfoService", () => {
       await middleware({ path, query: {} }, createMockRes(), next);
       expect(next).not.toHaveBeenCalled();
     }
-  });
-
-  it("has exactly 3 allowed endpoints", async () => {
-    const middleware = createSecuritiesProductInfoService();
-    const next = vi.fn();
-
-    let acceptedCount = 0;
-    for (const path of ALLOWED_PATHS) {
-      next.mockClear();
-      await middleware({ path, query: {} }, createMockRes(), next);
-      if (!next.mock.calls.length) acceptedCount++;
-    }
-
-    expect(acceptedCount).toBe(3);
-    expect(ALLOWED_PATHS).toHaveLength(3);
   });
 });

--- a/src/services/spcdeInfoService.test.js
+++ b/src/services/spcdeInfoService.test.js
@@ -1,7 +1,7 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
-process.env.DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY || "test-key";
+process.env.DATAGOKR_SERVICEKEY = "test-key";
 
 vi.mock("node-fetch", () => ({
   default: vi.fn(() =>
@@ -61,20 +61,5 @@ describe("createSpcdeInfoService", () => {
       await middleware({ path, query: {} }, createMockRes(), next);
       expect(next).not.toHaveBeenCalled();
     }
-  });
-
-  it("has exactly 3 allowed endpoints", async () => {
-    const middleware = createSpcdeInfoService();
-    const next = vi.fn();
-
-    let acceptedCount = 0;
-    for (const path of ALLOWED_PATHS) {
-      next.mockClear();
-      await middleware({ path, query: {} }, createMockRes(), next);
-      if (!next.mock.calls.length) acceptedCount++;
-    }
-
-    expect(acceptedCount).toBe(3);
-    expect(ALLOWED_PATHS).toHaveLength(3);
   });
 });

--- a/src/services/spcdeInfoService.test.js
+++ b/src/services/spcdeInfoService.test.js
@@ -1,0 +1,80 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+process.env.DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY || "test-key";
+
+vi.mock("node-fetch", () => ({
+  default: vi.fn(() =>
+    Promise.resolve({
+      headers: { get: () => "application/xml" },
+      body: new PassThrough(),
+    }),
+  ),
+}));
+
+vi.mock("user-agents", () => ({
+  default: class {
+    toString() {
+      return "test-agent";
+    }
+  },
+}));
+
+const { default: createSpcdeInfoService } = await import(
+  "./spcdeInfoService.js"
+);
+
+const ALLOWED_PATHS = [
+  "/getRestDeInfo",
+  "/getAnniversaryInfo",
+  "/get24DivisionsInfo",
+];
+
+function createMockRes() {
+  const res = new PassThrough();
+  res.set = vi.fn();
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn();
+  return res;
+}
+
+describe("createSpcdeInfoService", () => {
+  it("returns a middleware function", () => {
+    const middleware = createSpcdeInfoService();
+    expect(typeof middleware).toBe("function");
+  });
+
+  it("calls next for disallowed paths", async () => {
+    const middleware = createSpcdeInfoService();
+    const next = vi.fn();
+
+    await middleware({ path: "/notAllowed", query: {} }, createMockRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("does not call next for allowed paths", async () => {
+    const middleware = createSpcdeInfoService();
+    const next = vi.fn();
+
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      await middleware({ path, query: {} }, createMockRes(), next);
+      expect(next).not.toHaveBeenCalled();
+    }
+  });
+
+  it("has exactly 3 allowed endpoints", async () => {
+    const middleware = createSpcdeInfoService();
+    const next = vi.fn();
+
+    let acceptedCount = 0;
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      await middleware({ path, query: {} }, createMockRes(), next);
+      if (!next.mock.calls.length) acceptedCount++;
+    }
+
+    expect(acceptedCount).toBe(3);
+    expect(ALLOWED_PATHS).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `common.js createService` covering proxy behavior, path validation, timeout handling, and fetch error handling
- Add unit tests for `spcdeInfoService` and `getSecuritiesProductInfoService` verifying allowed paths and service creation
- Update `plan.md`: mark completed test items, add JS→TS migration plan

## Test plan
- [x] All 16 tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)