### PR TITLE
Remove node-fetch, improve security and reliability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ COPY --from=builder /app/dist/ dist/
 ENV PORT=8080
 EXPOSE 8080
 
+USER bun
 CMD ["bun", "run", "start"]

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -1,12 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "apis-data-spcdeinfoservice",
       "dependencies": {
         "express": "^5.2.1",
-        "node-fetch": "^3.3.2",
         "user-agents": "^2.1.1",
       },
       "devDependencies": {
@@ -211,8 +209,6 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
-    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
-
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
@@ -245,11 +241,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
-
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
-
-    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -318,10 +310,6 @@
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
-    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
-
-    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
@@ -408,8 +396,6 @@
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx"], "bin": "bin/vite.js" }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vitest": ["vitest@4.1.0", "", { "dependencies": { "@vitest/expect": "4.1.0", "@vitest/mocker": "4.1.0", "@vitest/pretty-format": "4.1.0", "@vitest/runner": "4.1.0", "@vitest/snapshot": "4.1.0", "@vitest/spy": "4.1.0", "@vitest/utils": "4.1.0", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.0", "@vitest/browser-preview": "4.1.0", "@vitest/browser-webdriverio": "4.1.0", "@vitest/ui": "4.1.0", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw=="],
-
-    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "description": "",
   "dependencies": {
     "express": "^5.2.1",
-    "node-fetch": "^3.3.2",
     "user-agents": "^2.1.1"
   },
   "type": "module",

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -3,9 +3,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 process.env.DATAGOKR_SERVICEKEY = "test-service-key";
 
-vi.mock("node-fetch", () => ({
-  default: vi.fn(),
-}));
+const fetchMock = vi.fn();
+globalThis.fetch = fetchMock;
+
+vi.mock("node:stream", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:stream");
+  return {
+    ...actual,
+    Readable: {
+      ...actual.Readable,
+      fromWeb: (stream: unknown) => stream,
+    },
+  };
+});
 
 vi.mock("user-agents", () => ({
   default: class {
@@ -15,7 +25,6 @@ vi.mock("user-agents", () => ({
   },
 }));
 
-const { default: fetch } = await import("node-fetch");
 const { createService } = await import("./common.js");
 
 function createMockRes() {
@@ -32,12 +41,13 @@ function createMockRes() {
 
 describe("createService", () => {
   beforeEach(() => {
-    (fetch as unknown as ReturnType<typeof vi.fn>).mockReset();
+    fetchMock.mockReset();
   });
 
   it("proxies request for an allowed path with correct URL, headers, and streaming", async () => {
     const responseBody = new PassThrough();
-    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    fetchMock.mockResolvedValueOnce({
+      status: 200,
       headers: {
         get: (name: string) =>
           name === "content-type" ? "application/xml" : null,
@@ -56,16 +66,14 @@ describe("createService", () => {
     await middleware(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledOnce();
 
-    const calledUrl = (fetch as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0][0];
+    const calledUrl = fetchMock.mock.calls[0][0];
     expect(calledUrl).toContain("https://api.example.com/getAllowed?");
     expect(calledUrl).toContain("numOfRows=10");
     expect(calledUrl).toContain("serviceKey=test-service-key");
 
-    const calledOptions = (fetch as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0][1];
+    const calledOptions = fetchMock.mock.calls[0][1];
     expect(calledOptions.method).toBe("GET");
     expect(calledOptions.headers["User-Agent"]).toBe("mock-user-agent");
 
@@ -90,14 +98,12 @@ describe("createService", () => {
     await middleware(req, res, next);
 
     expect(next).toHaveBeenCalledOnce();
-    expect(fetch).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("responds with 500 and timeout message on AbortError", async () => {
     const abortError = new DOMException("signal timed out", "AbortError");
-    (fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      abortError,
-    );
+    fetchMock.mockRejectedValueOnce(abortError);
 
     const middleware = createService(
       "https://api.example.com",
@@ -117,9 +123,7 @@ describe("createService", () => {
   });
 
   it("responds with 500 and service unavailable on generic fetch error", async () => {
-    (fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new Error("network failure"),
-    );
+    fetchMock.mockRejectedValueOnce(new Error("network failure"));
 
     const middleware = createService(
       "https://api.example.com",

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,11 +1,11 @@
+import { Readable } from "node:stream";
 import type { NextFunction, Request, Response } from "express";
-import fetch from "node-fetch";
 import UserAgent from "user-agents";
 
 export const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, OPTIONS",
-  "Access-Control-Allow-Headers": "*",
+  "Access-Control-Allow-Headers": "x-api-key, Content-Type",
 };
 
 const DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY;
@@ -48,7 +48,7 @@ export function createService(
         signal: AbortSignal.timeout(10000),
       });
 
-      res.set({
+      res.status(response.status).set({
         "Content-Type":
           response.headers.get("content-type") || "application/xml",
         ...CORS_HEADERS,
@@ -59,14 +59,17 @@ export function createService(
         return;
       }
 
-      response.body.pipe(res).on("error", (err: Error) => {
-        console.error("Pipe Error:", err);
-        if (!res.headersSent) {
-          res.status(500).end();
-        } else {
-          res.end();
-        }
-      });
+      // @ts-expect-error: ReadableStream type mismatch between Web API and Node.js
+      Readable.fromWeb(response.body)
+        .pipe(res)
+        .on("error", (err: Error) => {
+          console.error("Pipe Error:", err);
+          if (!res.headersSent) {
+            res.status(500).end();
+          } else {
+            res.end();
+          }
+        });
     } catch (e) {
       // Log detailed error internally
       console.error("Fetch Error:", e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,9 +58,17 @@ const server = app.listen(PORT, () => {
 
 function shutdown() {
   console.log("Shutting down gracefully...");
-  server.close(() => {
+  server.close((err) => {
+    if (err) {
+      console.error("Error shutting down server:", err);
+      process.exit(1);
+    }
     process.exit(0);
   });
+  setTimeout(() => {
+    console.error("Forced shutdown after timeout");
+    process.exit(1);
+  }, 5000).unref();
 }
 
 process.on("SIGTERM", shutdown);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ if (!AUTH_API_KEY) {
 
 const app = express();
 
+app.get("/health", (_req, res) => {
+  res.status(200).json({ status: "ok" });
+});
+
 app.use((req, res, next) => {
   if (req.method === "OPTIONS") {
     return res.set(CORS_HEADERS).status(204).send();
@@ -44,10 +48,20 @@ app.use(
 );
 
 app.use((_req, res) => {
-  res.status(404).send("Not Found");
+  res.status(404).json({ error: "Not Found" });
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Proxy server running on port ${PORT}`);
 });
+
+function shutdown() {
+  console.log("Shutting down gracefully...");
+  server.close(() => {
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/src/services/bidPublicInfoService.test.ts
+++ b/src/services/bidPublicInfoService.test.ts
@@ -3,14 +3,24 @@ import { describe, expect, it, vi } from "vitest";
 
 process.env.DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY || "test-key";
 
-vi.mock("node-fetch", () => ({
-  default: vi.fn(() =>
-    Promise.resolve({
-      headers: { get: () => "application/xml" },
-      body: new PassThrough(),
-    }),
-  ),
-}));
+globalThis.fetch = vi.fn(() =>
+  Promise.resolve({
+    status: 200,
+    headers: { get: () => "application/xml" },
+    body: new PassThrough(),
+  }),
+) as unknown as typeof fetch;
+
+vi.mock("node:stream", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:stream");
+  return {
+    ...actual,
+    Readable: {
+      ...actual.Readable,
+      fromWeb: (stream: unknown) => stream,
+    },
+  };
+});
 
 vi.mock("user-agents", () => ({
   default: class {

--- a/src/services/getSecuritiesProductInfoService.test.ts
+++ b/src/services/getSecuritiesProductInfoService.test.ts
@@ -3,14 +3,24 @@ import { describe, expect, it, vi } from "vitest";
 
 process.env.DATAGOKR_SERVICEKEY = "test-key";
 
-vi.mock("node-fetch", () => ({
-  default: vi.fn(() =>
-    Promise.resolve({
-      headers: { get: () => "application/xml" },
-      body: new PassThrough(),
-    }),
-  ),
-}));
+globalThis.fetch = vi.fn(() =>
+  Promise.resolve({
+    status: 200,
+    headers: { get: () => "application/xml" },
+    body: new PassThrough(),
+  }),
+) as unknown as typeof fetch;
+
+vi.mock("node:stream", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:stream");
+  return {
+    ...actual,
+    Readable: {
+      ...actual.Readable,
+      fromWeb: (stream: unknown) => stream,
+    },
+  };
+});
 
 vi.mock("user-agents", () => ({
   default: class {

--- a/src/services/spcdeInfoService.test.ts
+++ b/src/services/spcdeInfoService.test.ts
@@ -3,14 +3,24 @@ import { describe, expect, it, vi } from "vitest";
 
 process.env.DATAGOKR_SERVICEKEY = "test-key";
 
-vi.mock("node-fetch", () => ({
-  default: vi.fn(() =>
-    Promise.resolve({
-      headers: { get: () => "application/xml" },
-      body: new PassThrough(),
-    }),
-  ),
-}));
+globalThis.fetch = vi.fn(() =>
+  Promise.resolve({
+    status: 200,
+    headers: { get: () => "application/xml" },
+    body: new PassThrough(),
+  }),
+) as unknown as typeof fetch;
+
+vi.mock("node:stream", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:stream");
+  return {
+    ...actual,
+    Readable: {
+      ...actual.Readable,
+      fromWeb: (stream: unknown) => stream,
+    },
+  };
+});
 
 vi.mock("user-agents", () => ({
   default: class {


### PR DESCRIPTION
## Summary

- Replace `node-fetch` with native `fetch` API and use `Readable.fromWeb` for response streaming, removing an unnecessary dependency
- Add non-root `USER bun` directive in Dockerfile for improved container security
- Add `/health` endpoint for Cloud Run health checks and graceful shutdown handling (SIGTERM/SIGINT)
- Forward upstream HTTP status codes, restrict CORS headers to explicit values (`x-api-key, Content-Type`), and return JSON error responses
- Update all tests to use `globalThis.fetch` mock pattern matching the native fetch API

## Test plan

- [x] All 14 existing tests pass with new mock pattern
- [x] Lint and typecheck pass
- [ ] Verify `/health` endpoint returns `{"status":"ok"}` after deployment
- [ ] Verify proxied requests forward upstream status codes correctly
- [ ] Confirm container runs as non-root user in Cloud Run

🤖 Generated with [Claude Code](https://claude.com/claude-code)