### PR TITLE
Add KorService2 and PubDataOpnStdService proxy routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import express from "express";
 import { CORS_HEADERS } from "./common.js";
 import createBidPublicInfoService from "./services/bidPublicInfoService.js";
 import createSecuritiesProductInfoService from "./services/getSecuritiesProductInfoService.js";
+import createKorService from "./services/korService.js";
+import createPubDataOpnStdService from "./services/pubDataOpnStdService.js";
 import createSpcdeInfoService from "./services/spcdeInfoService.js";
 
 const AUTH_API_KEY = process.env.AUTH_API_KEY;
@@ -41,6 +43,8 @@ app.use((req, res, next) => {
 });
 
 app.use("/BidPublicInfoService", createBidPublicInfoService());
+app.use("/KorService2", createKorService());
+app.use("/PubDataOpnStdService", createPubDataOpnStdService());
 app.use("/SpcdeInfoService", createSpcdeInfoService());
 app.use(
   "/GetSecuritiesProductInfoService",

--- a/src/services/korService.test.ts
+++ b/src/services/korService.test.ts
@@ -1,7 +1,7 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
-process.env.DATAGOKR_SERVICEKEY = "test-key";
+process.env.DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY || "test-key";
 
 globalThis.fetch = vi.fn(() =>
   Promise.resolve({
@@ -70,9 +70,10 @@ describe("createKorService", () => {
 
   it("calls next for disallowed paths", async () => {
     const middleware = createKorService();
+    const req = { path: "/notAllowed", query: {} };
     const next = vi.fn();
 
-    await middleware({ path: "/notAllowed", query: {} }, createMockRes(), next);
+    await middleware(req, createMockRes(), next);
     expect(next).toHaveBeenCalledOnce();
   });
 
@@ -82,8 +83,25 @@ describe("createKorService", () => {
 
     for (const path of ALLOWED_PATHS) {
       next.mockClear();
-      await middleware({ path, query: {} }, createMockRes(), next);
+      const req = { path, query: {} };
+      await middleware(req, createMockRes(), next);
       expect(next).not.toHaveBeenCalled();
     }
+  });
+
+  it("has exactly 15 allowed endpoints", async () => {
+    const middleware = createKorService();
+    const next = vi.fn();
+
+    let acceptedCount = 0;
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      const req = { path, query: {} };
+      await middleware(req, createMockRes(), next);
+      if (!next.mock.calls.length) acceptedCount++;
+    }
+
+    expect(acceptedCount).toBe(15);
+    expect(ALLOWED_PATHS).toHaveLength(15);
   });
 });

--- a/src/services/korService.test.ts
+++ b/src/services/korService.test.ts
@@ -1,0 +1,89 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+process.env.DATAGOKR_SERVICEKEY = "test-key";
+
+globalThis.fetch = vi.fn(() =>
+  Promise.resolve({
+    status: 200,
+    headers: { get: () => "application/xml" },
+    body: new PassThrough(),
+  }),
+) as unknown as typeof fetch;
+
+vi.mock("node:stream", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:stream");
+  return {
+    ...actual,
+    Readable: {
+      ...actual.Readable,
+      fromWeb: (stream: unknown) => stream,
+    },
+  };
+});
+
+vi.mock("user-agents", () => ({
+  default: class {
+    toString() {
+      return "test-agent";
+    }
+  },
+}));
+
+const { default: createKorService } = await import("./korService.js");
+
+const ALLOWED_PATHS = [
+  "/areaCode2",
+  "/detailPetTour2",
+  "/categoryCode2",
+  "/areaBasedList2",
+  "/locationBasedList2",
+  "/searchKeyword2",
+  "/searchFestival2",
+  "/searchStay2",
+  "/detailCommon2",
+  "/detailIntro2",
+  "/detailInfo2",
+  "/detailImage2",
+  "/lclsSystmCode2",
+  "/areaBasedSyncList2",
+  "/ldongCode2",
+];
+
+function createMockRes() {
+  const res = new PassThrough() as PassThrough & {
+    set: ReturnType<typeof vi.fn>;
+    status: ReturnType<typeof vi.fn>;
+    json: ReturnType<typeof vi.fn>;
+  };
+  res.set = vi.fn();
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn();
+  return res;
+}
+
+describe("createKorService", () => {
+  it("returns a middleware function", () => {
+    const middleware = createKorService();
+    expect(typeof middleware).toBe("function");
+  });
+
+  it("calls next for disallowed paths", async () => {
+    const middleware = createKorService();
+    const next = vi.fn();
+
+    await middleware({ path: "/notAllowed", query: {} }, createMockRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("does not call next for allowed paths", async () => {
+    const middleware = createKorService();
+    const next = vi.fn();
+
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      await middleware({ path, query: {} }, createMockRes(), next);
+      expect(next).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/services/korService.ts
+++ b/src/services/korService.ts
@@ -1,0 +1,27 @@
+import { createService } from "../common.js";
+
+/**
+ * Creates a service client for the KorService2 API (국문 관광정보 서비스) with access restricted to specific endpoints.
+ * @return {object} A configured service client for the KorService2 API.
+ */
+export default function createKorService() {
+  const baseUrl = "https://apis.data.go.kr/B551011/KorService2";
+  const allowedPaths = new Set([
+    "/areaCode2",
+    "/detailPetTour2",
+    "/categoryCode2",
+    "/areaBasedList2",
+    "/locationBasedList2",
+    "/searchKeyword2",
+    "/searchFestival2",
+    "/searchStay2",
+    "/detailCommon2",
+    "/detailIntro2",
+    "/detailInfo2",
+    "/detailImage2",
+    "/lclsSystmCode2",
+    "/areaBasedSyncList2",
+    "/ldongCode2",
+  ]);
+  return createService(baseUrl, allowedPaths);
+}

--- a/src/services/pubDataOpnStdService.test.ts
+++ b/src/services/pubDataOpnStdService.test.ts
@@ -1,7 +1,7 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 
-process.env.DATAGOKR_SERVICEKEY = "test-key";
+process.env.DATAGOKR_SERVICEKEY = process.env.DATAGOKR_SERVICEKEY || "test-key";
 
 globalThis.fetch = vi.fn(() =>
   Promise.resolve({
@@ -60,9 +60,10 @@ describe("createPubDataOpnStdService", () => {
 
   it("calls next for disallowed paths", async () => {
     const middleware = createPubDataOpnStdService();
+    const req = { path: "/notAllowed", query: {} };
     const next = vi.fn();
 
-    await middleware({ path: "/notAllowed", query: {} }, createMockRes(), next);
+    await middleware(req, createMockRes(), next);
     expect(next).toHaveBeenCalledOnce();
   });
 
@@ -72,8 +73,25 @@ describe("createPubDataOpnStdService", () => {
 
     for (const path of ALLOWED_PATHS) {
       next.mockClear();
-      await middleware({ path, query: {} }, createMockRes(), next);
+      const req = { path, query: {} };
+      await middleware(req, createMockRes(), next);
       expect(next).not.toHaveBeenCalled();
     }
+  });
+
+  it("has exactly 3 allowed endpoints", async () => {
+    const middleware = createPubDataOpnStdService();
+    const next = vi.fn();
+
+    let acceptedCount = 0;
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      const req = { path, query: {} };
+      await middleware(req, createMockRes(), next);
+      if (!next.mock.calls.length) acceptedCount++;
+    }
+
+    expect(acceptedCount).toBe(3);
+    expect(ALLOWED_PATHS).toHaveLength(3);
   });
 });

--- a/src/services/pubDataOpnStdService.test.ts
+++ b/src/services/pubDataOpnStdService.test.ts
@@ -1,0 +1,79 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+process.env.DATAGOKR_SERVICEKEY = "test-key";
+
+globalThis.fetch = vi.fn(() =>
+  Promise.resolve({
+    status: 200,
+    headers: { get: () => "application/xml" },
+    body: new PassThrough(),
+  }),
+) as unknown as typeof fetch;
+
+vi.mock("node:stream", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:stream");
+  return {
+    ...actual,
+    Readable: {
+      ...actual.Readable,
+      fromWeb: (stream: unknown) => stream,
+    },
+  };
+});
+
+vi.mock("user-agents", () => ({
+  default: class {
+    toString() {
+      return "test-agent";
+    }
+  },
+}));
+
+const { default: createPubDataOpnStdService } = await import(
+  "./pubDataOpnStdService.js"
+);
+
+const ALLOWED_PATHS = [
+  "/getDataSetOpnStdBidPblancInfo",
+  "/getDataSetOpnStdScsbidInfo",
+  "/getDataSetOpnStdCntrctInfo",
+];
+
+function createMockRes() {
+  const res = new PassThrough() as PassThrough & {
+    set: ReturnType<typeof vi.fn>;
+    status: ReturnType<typeof vi.fn>;
+    json: ReturnType<typeof vi.fn>;
+  };
+  res.set = vi.fn();
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn();
+  return res;
+}
+
+describe("createPubDataOpnStdService", () => {
+  it("returns a middleware function", () => {
+    const middleware = createPubDataOpnStdService();
+    expect(typeof middleware).toBe("function");
+  });
+
+  it("calls next for disallowed paths", async () => {
+    const middleware = createPubDataOpnStdService();
+    const next = vi.fn();
+
+    await middleware({ path: "/notAllowed", query: {} }, createMockRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("does not call next for allowed paths", async () => {
+    const middleware = createPubDataOpnStdService();
+    const next = vi.fn();
+
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      await middleware({ path, query: {} }, createMockRes(), next);
+      expect(next).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/services/pubDataOpnStdService.ts
+++ b/src/services/pubDataOpnStdService.ts
@@ -1,0 +1,15 @@
+import { createService } from "../common.js";
+
+/**
+ * Creates a service client for the PubDataOpnStdService API (나라장터 공공데이터개방표준서비스) with access restricted to specific endpoints.
+ * @return {object} A configured service client for the PubDataOpnStdService API.
+ */
+export default function createPubDataOpnStdService() {
+  const baseUrl = "https://apis.data.go.kr/1230000/ao/PubDataOpnStdService";
+  const allowedPaths = new Set([
+    "/getDataSetOpnStdBidPblancInfo",
+    "/getDataSetOpnStdScsbidInfo",
+    "/getDataSetOpnStdCntrctInfo",
+  ]);
+  return createService(baseUrl, allowedPaths);
+}


### PR DESCRIPTION
## Summary

- Add KorService2 proxy route for Korean tourism info API (국문 관광정보 서비스) with 15 allowed endpoints
- Add PubDataOpnStdService proxy route for public procurement open standard API (나라장터 공공데이터개방표준서비스) with 3 allowed endpoints
- Both services follow the existing `createService` pattern and include tests for middleware behavior and path allowlisting

## Test plan

- [x] All 20 existing tests pass (`bun run test`)
- [x] New tests verify middleware returns a function, calls `next` for disallowed paths, and proxies allowed paths
- [x] Lint and typecheck pass via pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)