### PR TITLE
Add sjFestival (세종 축제) proxy route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import createBidPublicInfoService from "./services/bidPublicInfoService.js";
 import createSecuritiesProductInfoService from "./services/getSecuritiesProductInfoService.js";
 import createKorService from "./services/korService.js";
 import createPubDataOpnStdService from "./services/pubDataOpnStdService.js";
+import createSjFestival from "./services/sjFestival.js";
 import createSpcdeInfoService from "./services/spcdeInfoService.js";
 
 const AUTH_API_KEY = process.env.AUTH_API_KEY;
@@ -45,6 +46,7 @@ app.use((req, res, next) => {
 app.use("/BidPublicInfoService", createBidPublicInfoService());
 app.use("/KorService2", createKorService());
 app.use("/PubDataOpnStdService", createPubDataOpnStdService());
+app.use("/sjFestival", createSjFestival());
 app.use("/SpcdeInfoService", createSpcdeInfoService());
 app.use(
   "/GetSecuritiesProductInfoService",

--- a/src/services/sjFestival.test.ts
+++ b/src/services/sjFestival.test.ts
@@ -70,4 +70,28 @@ describe("createSjFestival", () => {
       expect(next).not.toHaveBeenCalled();
     }
   });
+
+  it("proxies request with correct URL and serviceKey", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
+    const middleware = createSjFestival();
+    const res = createMockRes();
+    const next = vi.fn();
+
+    await middleware(
+      { path: "/sj_00000360", query: { pageIndex: "1" } },
+      res,
+      next,
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    const [fetchUrl] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    const targetUrl = new URL(fetchUrl);
+    expect(targetUrl.origin + targetUrl.pathname).toBe(
+      "https://apis.data.go.kr/5690000/sjFestival/sj_00000360",
+    );
+    expect(targetUrl.searchParams.get("pageIndex")).toBe("1");
+    expect(targetUrl.searchParams.get("serviceKey")).toBe("test-key");
+  });
 });

--- a/src/services/sjFestival.test.ts
+++ b/src/services/sjFestival.test.ts
@@ -1,0 +1,73 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+
+process.env.DATAGOKR_SERVICEKEY = "test-key";
+
+globalThis.fetch = vi.fn(() =>
+  Promise.resolve({
+    status: 200,
+    headers: { get: () => "application/xml" },
+    body: new PassThrough(),
+  }),
+) as unknown as typeof fetch;
+
+vi.mock("node:stream", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:stream");
+  return {
+    ...actual,
+    Readable: {
+      ...actual.Readable,
+      fromWeb: (stream: unknown) => stream,
+    },
+  };
+});
+
+vi.mock("user-agents", () => ({
+  default: class {
+    toString() {
+      return "test-agent";
+    }
+  },
+}));
+
+const { default: createSjFestival } = await import("./sjFestival.js");
+
+const ALLOWED_PATHS = ["/sj_00000360"];
+
+function createMockRes() {
+  const res = new PassThrough() as PassThrough & {
+    set: ReturnType<typeof vi.fn>;
+    status: ReturnType<typeof vi.fn>;
+    json: ReturnType<typeof vi.fn>;
+  };
+  res.set = vi.fn();
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn();
+  return res;
+}
+
+describe("createSjFestival", () => {
+  it("returns a middleware function", () => {
+    const middleware = createSjFestival();
+    expect(typeof middleware).toBe("function");
+  });
+
+  it("calls next for disallowed paths", async () => {
+    const middleware = createSjFestival();
+    const next = vi.fn();
+
+    await middleware({ path: "/notAllowed", query: {} }, createMockRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("does not call next for allowed paths", async () => {
+    const middleware = createSjFestival();
+    const next = vi.fn();
+
+    for (const path of ALLOWED_PATHS) {
+      next.mockClear();
+      await middleware({ path, query: {} }, createMockRes(), next);
+      expect(next).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/services/sjFestival.ts
+++ b/src/services/sjFestival.ts
@@ -1,8 +1,8 @@
 import { createService } from "../common.js";
 
 /**
- * Creates a service client for the Sejong Festival API with access restricted to specific endpoints.
- * @return {object} A configured service client for the sjFestival API.
+ * Creates an Express middleware for proxying requests to the Sejong Festival API.
+ * Access is restricted to a specific set of endpoints.
  */
 export default function createSjFestival() {
   const baseUrl = "https://apis.data.go.kr/5690000/sjFestival";

--- a/src/services/sjFestival.ts
+++ b/src/services/sjFestival.ts
@@ -1,0 +1,11 @@
+import { createService } from "../common.js";
+
+/**
+ * Creates a service client for the Sejong Festival API with access restricted to specific endpoints.
+ * @return {object} A configured service client for the sjFestival API.
+ */
+export default function createSjFestival() {
+  const baseUrl = "https://apis.data.go.kr/5690000/sjFestival";
+  const allowedPaths = new Set(["/sj_00000360"]);
+  return createService(baseUrl, allowedPaths);
+}


### PR DESCRIPTION
## Summary
- Add proxy service for the Sejong Special Autonomous City Festival API (`apis.data.go.kr/5690000/sjFestival`)
- Expose `/sjFestival/sj_00000360` endpoint following existing service pattern
- Include unit tests matching established test conventions

## Test plan
- [x] `bun run test` — all 25 tests pass (7 test files)
- [x] `bun run lint` — no issues
- [x] `bun run build` — compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)