### PR TITLE
Add retry with exponential backoff for upstream fetch

### DIFF
--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -124,6 +124,9 @@ describe("createService", () => {
     await promise;
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(res.set).toHaveBeenCalledWith(
+      expect.objectContaining({ "Access-Control-Allow-Origin": "*" }),
+    );
     expect(res.status).toHaveBeenCalledWith(504);
     expect(res.json).toHaveBeenCalledWith({
       error: "Gateway Timeout",
@@ -148,6 +151,9 @@ describe("createService", () => {
     await promise;
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(res.set).toHaveBeenCalledWith(
+      expect.objectContaining({ "Access-Control-Allow-Origin": "*" }),
+    );
     expect(res.status).toHaveBeenCalledWith(502);
     expect(res.json).toHaveBeenCalledWith({
       error: "Bad Gateway",
@@ -162,6 +168,7 @@ describe("createService", () => {
         status: 503,
         headers: { get: () => null },
         body: null,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
       })
       .mockResolvedValueOnce({
         status: 200,
@@ -217,6 +224,7 @@ describe("createService", () => {
       status: 503,
       headers: { get: () => null },
       body: null,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
     });
 
     const middleware = createService(

--- a/src/common.test.ts
+++ b/src/common.test.ts
@@ -1,5 +1,5 @@
 import { PassThrough } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 process.env.DATAGOKR_SERVICEKEY = "test-service-key";
 
@@ -41,7 +41,12 @@ function createMockRes() {
 
 describe("createService", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("proxies request for an allowed path with correct URL, headers, and streaming", async () => {
@@ -101,9 +106,9 @@ describe("createService", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("responds with 500 and timeout message on AbortError", async () => {
+  it("responds with 504 and timeout message after all retries exhausted on AbortError", async () => {
     const abortError = new DOMException("signal timed out", "AbortError");
-    fetchMock.mockRejectedValueOnce(abortError);
+    fetchMock.mockRejectedValue(abortError);
 
     const middleware = createService(
       "https://api.example.com",
@@ -113,17 +118,85 @@ describe("createService", () => {
     const res = createMockRes();
     const next = vi.fn();
 
-    await middleware(req, res, next);
+    const promise = middleware(req, res, next);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
 
-    expect(res.status).toHaveBeenCalledWith(500);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(res.status).toHaveBeenCalledWith(504);
     expect(res.json).toHaveBeenCalledWith({
-      error: "Request Timeout",
+      error: "Gateway Timeout",
       message: "Request timed out",
     });
   });
 
-  it("responds with 500 and service unavailable on generic fetch error", async () => {
-    fetchMock.mockRejectedValueOnce(new Error("network failure"));
+  it("responds with 502 and bad gateway on generic fetch error after all retries", async () => {
+    fetchMock.mockRejectedValue(new Error("network failure"));
+
+    const middleware = createService(
+      "https://api.example.com",
+      new Set(["/path"]),
+    );
+    const req = { path: "/path", query: {} };
+    const res = createMockRes();
+    const next = vi.fn();
+
+    const promise = middleware(req, res, next);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(res.status).toHaveBeenCalledWith(502);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Bad Gateway",
+      message: "Unable to process request",
+    });
+  });
+
+  it("retries on 5xx and succeeds on subsequent attempt", async () => {
+    const responseBody = new PassThrough();
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 503,
+        headers: { get: () => null },
+        body: null,
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        headers: {
+          get: (name: string) =>
+            name === "content-type" ? "application/xml" : null,
+        },
+        body: responseBody,
+      });
+
+    const middleware = createService(
+      "https://api.example.com",
+      new Set(["/path"]),
+    );
+    const req = { path: "/path", query: {} };
+    const res = createMockRes();
+    const next = vi.fn();
+
+    const promise = middleware(req, res, next);
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("does not retry on 4xx responses", async () => {
+    fetchMock.mockResolvedValueOnce({
+      status: 404,
+      headers: {
+        get: (name: string) =>
+          name === "content-type" ? "application/json" : null,
+      },
+      body: null,
+    });
 
     const middleware = createService(
       "https://api.example.com",
@@ -135,9 +208,34 @@ describe("createService", () => {
 
     await middleware(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(500);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("responds with 502 after all retries exhausted on 5xx", async () => {
+    fetchMock.mockResolvedValue({
+      status: 503,
+      headers: { get: () => null },
+      body: null,
+    });
+
+    const middleware = createService(
+      "https://api.example.com",
+      new Set(["/path"]),
+    );
+    const req = { path: "/path", query: {} };
+    const res = createMockRes();
+    const next = vi.fn();
+
+    const promise = middleware(req, res, next);
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(res.status).toHaveBeenCalledWith(502);
     expect(res.json).toHaveBeenCalledWith({
-      error: "Service Unavailable",
+      error: "Bad Gateway",
       message: "Unable to process request",
     });
   });

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,6 +2,65 @@ import { Readable } from "node:stream";
 import type { NextFunction, Request, Response } from "express";
 import UserAgent from "user-agents";
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+class UpstreamError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly isTimeout: boolean,
+  ) {
+    super(message);
+    this.name = "UpstreamError";
+  }
+}
+
+const MAX_RETRIES = 2;
+const TIMEOUT_MS = 10_000;
+const BACKOFF_BASE_MS = 1_000;
+
+async function fetchWithRetry(
+  url: string,
+  headers: Record<string, string>,
+): Promise<globalThis.Response> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers,
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      });
+
+      if (response.status < 500) {
+        return response;
+      }
+
+      lastError = new UpstreamError(
+        `Upstream returned ${response.status}`,
+        502,
+        false,
+      );
+    } catch (e) {
+      const isTimeout = (e as Error).name === "AbortError";
+      lastError = new UpstreamError(
+        isTimeout ? "Request timed out" : (e as Error).message,
+        isTimeout ? 504 : 502,
+        isTimeout,
+      );
+    }
+
+    if (attempt < MAX_RETRIES) {
+      await sleep(BACKOFF_BASE_MS * 2 ** attempt);
+    }
+  }
+
+  throw lastError;
+}
+
 export const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, OPTIONS",
@@ -42,25 +101,23 @@ export function createService(
     const randomUserAgent = new UserAgent().toString();
 
     try {
-      const response = await fetch(targetUrl, {
-        method: "GET",
-        headers: { "User-Agent": randomUserAgent },
-        signal: AbortSignal.timeout(10000),
+      const upstream = await fetchWithRetry(targetUrl, {
+        "User-Agent": randomUserAgent,
       });
 
-      res.status(response.status).set({
+      res.status(upstream.status).set({
         "Content-Type":
-          response.headers.get("content-type") || "application/xml",
+          upstream.headers.get("content-type") || "application/xml",
         ...CORS_HEADERS,
       });
 
-      if (!response.body) {
+      if (!upstream.body) {
         res.end();
         return;
       }
 
       // @ts-expect-error: ReadableStream type mismatch between Web API and Node.js
-      Readable.fromWeb(response.body)
+      Readable.fromWeb(upstream.body)
         .pipe(res)
         .on("error", (err: Error) => {
           console.error("Pipe Error:", err);
@@ -71,15 +128,20 @@ export function createService(
           }
         });
     } catch (e) {
-      // Log detailed error internally
       console.error("Fetch Error:", e);
-      const isTimeoutError = (e as Error).name === "AbortError";
-      res.status(500).json({
-        error: isTimeoutError ? "Request Timeout" : "Service Unavailable",
-        message: isTimeoutError
-          ? "Request timed out"
-          : "Unable to process request",
-      });
+      if (e instanceof UpstreamError) {
+        res.status(e.statusCode).json({
+          error: e.isTimeout ? "Gateway Timeout" : "Bad Gateway",
+          message: e.isTimeout
+            ? "Request timed out"
+            : "Unable to process request",
+        });
+      } else {
+        res.status(502).json({
+          error: "Bad Gateway",
+          message: "Unable to process request",
+        });
+      }
     }
   };
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -39,15 +39,17 @@ async function fetchWithRetry(
         return response;
       }
 
+      await response.arrayBuffer();
       lastError = new UpstreamError(
         `Upstream returned ${response.status}`,
         502,
         false,
       );
     } catch (e) {
-      const isTimeout = (e as Error).name === "AbortError";
+      const isTimeout = e instanceof Error && e.name === "AbortError";
+      const message = e instanceof Error ? e.message : String(e);
       lastError = new UpstreamError(
-        isTimeout ? "Request timed out" : (e as Error).message,
+        isTimeout ? "Request timed out" : message,
         isTimeout ? 504 : 502,
         isTimeout,
       );
@@ -129,6 +131,7 @@ export function createService(
         });
     } catch (e) {
       console.error("Fetch Error:", e);
+      res.set(CORS_HEADERS);
       if (e instanceof UpstreamError) {
         res.status(e.statusCode).json({
           error: e.isTimeout ? "Gateway Timeout" : "Bad Gateway",


### PR DESCRIPTION
## Summary
- Upstream `fetch` 호출에 재시도 로직 추가 (최대 3회 시도, 지수 백오프 1s/2s)
- 네트워크 에러, 타임아웃, 5xx 응답 시 자동 재시도; 4xx는 즉시 반환
- 에러 응답을 적절한 게이트웨이 상태 코드로 변경 (500 → 502/504)

## Test plan
- [x] 기존 테스트 수정 (새로운 상태 코드 및 재시도 횟수 반영)
- [x] 5xx 후 성공 재시도 테스트 추가
- [x] 4xx 재시도 안 함 테스트 추가
- [x] 모든 재시도 실패 시 502 반환 테스트 추가
- [x] `bun run test` — 29 tests passed
- [x] `bun run build` — 성공
- [x] `bun run lint` — 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)