### PR TITLE
[FEAT] Migrate image registry from GCR to Artifact Registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Both secrets managed via Google Secret Manager (see `cloudbuild.yaml`).
 
 ## Deployment
 
-Cloud Build (`cloudbuild.yaml`): multi-stage Docker build (golang:1.24-alpine → distroless/static-debian12:nonroot), push to GCR, deploy to Cloud Run in `asia-northeast3`. Project: `workflow-knue`.
+Cloud Build (`cloudbuild.yaml`): multi-stage Docker build (golang:1.24-alpine → distroless/static-debian12:nonroot), push to Artifact Registry (`asia-northeast3-docker.pkg.dev/workflow-knue/cloud-run-images`), deploy to Cloud Run in `asia-northeast3`. Project: `workflow-knue`.
 
 Debug image: swap `:nonroot` to `:debug-nonroot` for BusyBox shell.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ curl -H "x-api-key: YOUR_API_KEY" \
 
 ## Deployment
 
-Cloud Build (`cloudbuild.yaml`) → GCR → Cloud Run `asia-northeast3` (project `workflow-knue`).
+Cloud Build (`cloudbuild.yaml`) → Artifact Registry → Cloud Run `asia-northeast3` (project `workflow-knue`).
 Secrets managed via Google Secret Manager.
 
 > **Debug image:** distroless has no shell. Swap `gcr.io/distroless/static-debian12:nonroot`

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,14 +4,14 @@ steps:
     args:
       - "build"
       - "-t"
-      - "gcr.io/workflow-knue/apis-data-spcdeinfoservice:$SHORT_SHA"
+      - "asia-northeast3-docker.pkg.dev/workflow-knue/cloud-run-images/apis-data-spcdeinfoservice:$SHORT_SHA"
       - "."
 
   # 2. 이미지 Push
   - name: "gcr.io/cloud-builders/docker"
     args:
       - "push"
-      - "gcr.io/workflow-knue/apis-data-spcdeinfoservice:$SHORT_SHA"
+      - "asia-northeast3-docker.pkg.dev/workflow-knue/cloud-run-images/apis-data-spcdeinfoservice:$SHORT_SHA"
 
   # 3. Cloud Run 배포
   - name: "gcr.io/cloud-builders/gcloud"
@@ -21,7 +21,7 @@ steps:
       - "deploy"
       - "apis-data-spcdeinfoservice"
       - "--image"
-      - "gcr.io/workflow-knue/apis-data-spcdeinfoservice:$SHORT_SHA"
+      - "asia-northeast3-docker.pkg.dev/workflow-knue/cloud-run-images/apis-data-spcdeinfoservice:$SHORT_SHA"
       - "--region"
       - "asia-northeast3"
       - "--platform"
@@ -31,4 +31,4 @@ steps:
       - "DATAGOKR_SERVICEKEY=DATAGOKR_SERVICEKEY:latest,AUTH_API_KEY=AUTH_API_KEY:latest"
 
 images:
-  - "gcr.io/workflow-knue/apis-data-spcdeinfoservice:$SHORT_SHA"
+  - "asia-northeast3-docker.pkg.dev/workflow-knue/cloud-run-images/apis-data-spcdeinfoservice:$SHORT_SHA"


### PR DESCRIPTION
## Summary

- `gcr.io/workflow-knue/apis-data-spcdeinfoservice` → `asia-northeast3-docker.pkg.dev/workflow-knue/cloud-run-images/apis-data-spcdeinfoservice`
- AR 저장소에 cleanup policy 적용 완료 (최신 5개 유지, 30일 후 삭제)
- Cloud Build SA에 `artifactregistry.writer` 권한 부여 완료
- gcr.io sunset 대응

## Pre-merge checklist (already done)

- [x] `cloud-run-images` AR 저장소 생성 (`asia-northeast3`)
- [x] Cleanup policy 적용 (keep-latest-5 + delete-old-30d)
- [x] Cloud Build SA IAM binding 추가

## Post-merge checklist

- [ ] Cloud Build 트리거 편집 → Ignored files 추가 (`**/*.md`, `.gitignore`, `lefthook.yml`)
- [ ] 첫 빌드 후 AR 콘솔에서 이미지 확인
- [ ] `/health` 200 응답 확인
- [ ] 6회 배포 후 오래된 이미지 자동 삭제 확인

## Test plan

1. PR 머지 → Cloud Build 자동 트리거
2. Cloud Build 로그: AR 경로로 push 성공
3. Cloud Run 새 revision: AR 이미지 사용
4. `curl https://<service-url>/health` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)