### PR TITLE
fix(build): upgrade builder to go1.25, add post-deploy health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 ARG TARGETARCH
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,5 +40,27 @@ steps:
       - "--timeout"
       - "30s"
 
+  # 4. 배포 검증
+  - name: "gcr.io/cloud-builders/gcloud"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        URL=$(gcloud run services describe apis-data-spcdeinfoservice \
+          --region=asia-northeast3 --platform=managed \
+          --format='value(status.url)')
+        echo "Checking $URL/health"
+        for i in 1 2 3 4 5; do
+          STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$URL/health")
+          if [ "$STATUS" = "200" ]; then
+            echo "Health check passed"
+            exit 0
+          fi
+          echo "Attempt $i: HTTP $STATUS — retrying in 5s"
+          sleep 5
+        done
+        echo "Health check failed after 5 attempts"
+        exit 1
+
 images:
   - "asia-northeast3-docker.pkg.dev/workflow-knue/cloud-run-images/apis-data-spcdeinfoservice:$SHORT_SHA"


### PR DESCRIPTION
go.mod requires go 1.25.0 but Dockerfile used golang:1.24-alpine,
causing all Cloud Build runs to fail since go1.25 was set.

Post-deploy step curls /health (5 retries, 5s apart) and exits
non-zero on failure — builds now surface deployment regressions
instead of succeeding silently on a broken service.