### PR TITLE
feat(proxy): in-memory caching, retry timeout fix, sweep harness

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -7,7 +7,7 @@
 ## Next
 
 - [ ] Add `tools/sweep.sh` for periodic harness checks
-- [ ] Align retry budget with Cloud Run request timeout: `MaxRetries=2` + `ResponseHeaderTimeout=10s` + backoffs = ~33s exceeds `--timeout 30s`. Either lower Cloud Run timeout to ≥90s or cap retries to 1. See `internal/proxy/retry.go` + `cloudbuild.yaml`.
+- [x] Align retry budget with Cloud Run request timeout: capped `MaxRetries=1`, reducing maximum duration budget to ~11s, which is well below the `--timeout 30s` limit.
 
 ## Someday
 

--- a/backlog.md
+++ b/backlog.md
@@ -7,7 +7,7 @@
 ## Next
 
 - [x] Add `tools/sweep.sh` for periodic harness checks and integrated with lefthook pre-commit
-- [x] Align retry budget with Cloud Run request timeout: capped `MaxRetries=1`, reducing maximum duration budget to ~11s, which is well below the `--timeout 30s` limit.
+- [x] Align retry budget with Cloud Run request timeout: capped `MaxRetries=1`, giving a worst-case header phase of ~21s (2×10s `ResponseHeaderTimeout` + 1s backoff), well below the `--timeout 30s` limit.
 
 ## Someday
 

--- a/backlog.md
+++ b/backlog.md
@@ -6,7 +6,7 @@
 
 ## Next
 
-- [ ] Add `tools/sweep.sh` for periodic harness checks
+- [x] Add `tools/sweep.sh` for periodic harness checks and integrated with lefthook pre-commit
 - [x] Align retry budget with Cloud Run request timeout: capped `MaxRetries=1`, reducing maximum duration budget to ~11s, which is well below the `--timeout 30s` limit.
 
 ## Someday

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -87,8 +87,12 @@ Swap base image in Dockerfile: `:nonroot` → `:debug-nonroot` for BusyBox shell
 | `AUTH_API_KEY` | Yes | Client auth key, checked via `x-api-key` header |
 | `DATAGOKR_SERVICEKEY` | Yes | Injected as query param into data.go.kr requests |
 | `PORT` | No | HTTP listen port (default: 3000; Dockerfile sets 8080) |
+| `CACHE_ENABLED` | No | Set to `"true"` to enable in-memory response caching (default: off) |
+| `CACHE_TTL_MINUTES` | No | Cache TTL in minutes when `CACHE_ENABLED=true` (default: 10) |
 
-Both secrets managed via Google Secret Manager (`workflow-knue` project).
+`AUTH_API_KEY` and `DATAGOKR_SERVICEKEY` managed via Google Secret Manager (`workflow-knue` project).
+
+**Cache limitation:** responses are cached based on HTTP status code only. data.go.kr returns HTTP 200 for some error conditions (e.g. rate-limit exceeded, invalid service key). These error responses will be cached for the full TTL. Monitor for `cache: stored key=` log lines when diagnosing unexpected error runs.
 
 ## Common Failures
 
@@ -113,8 +117,8 @@ Both secrets managed via Google Secret Manager (`workflow-knue` project).
 **Manual.** Run between features:
 
 ```bash
-# No tools/sweep.sh yet — manual checks:
-golangci-lint run ./...
-go test ./... -race
-grep -r "serviceKey\|AUTH_API_KEY" internal/ --include="*.go"  # verify no secrets in logs
+tools/sweep.sh        # convention + format + test checks
+go test ./... -race   # race detector
 ```
+
+`tools/sweep.sh` also runs automatically as a lefthook pre-commit hook.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,122 @@
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+// Cache defines the caching operations required.
+type Cache interface {
+	Set(key string, val interface{}, ttl time.Duration)
+	Get(key string) (interface{}, bool)
+	Delete(key string)
+	Close()
+}
+
+type cacheItem struct {
+	value      interface{}
+	expiration int64 // unix nano timestamp
+}
+
+func (item *cacheItem) expired() bool {
+	if item.expiration == 0 {
+		return false
+	}
+	return time.Now().UnixNano() > item.expiration
+}
+
+// InMemoryCache provides a thread-safe, TTL-based caching layer.
+type InMemoryCache struct {
+	mu      sync.RWMutex
+	items   map[string]cacheItem
+	cleanup time.Duration
+	stop    chan struct{}
+}
+
+// NewInMemoryCache instantiates a thread-safe memory cache.
+// A janitor goroutine will run every cleanupInterval if greater than 0.
+func NewInMemoryCache(cleanupInterval time.Duration) *InMemoryCache {
+	c := &InMemoryCache{
+		items:   make(map[string]cacheItem),
+		cleanup: cleanupInterval,
+		stop:    make(chan struct{}),
+	}
+	if cleanupInterval > 0 {
+		go c.startJanitor()
+	}
+	return c
+}
+
+// Set stores a value inside the cache with a specified TTL.
+func (c *InMemoryCache) Set(key string, val interface{}, ttl time.Duration) {
+	var exp int64
+	if ttl > 0 {
+		exp = time.Now().Add(ttl).UnixNano()
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items[key] = cacheItem{
+		value:      val,
+		expiration: exp,
+	}
+}
+
+// Get retrieves a value if it exists and is not expired.
+func (c *InMemoryCache) Get(key string) (interface{}, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	item, found := c.items[key]
+	if !found {
+		return nil, false
+	}
+
+	if item.expired() {
+		return nil, false
+	}
+
+	return item.value, true
+}
+
+// Delete removes a key immediately from the store.
+func (c *InMemoryCache) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.items, key)
+}
+
+// Close shuts down the janitor cleanup goroutine.
+func (c *InMemoryCache) Close() {
+	if c.stop != nil {
+		close(c.stop)
+	}
+}
+
+func (c *InMemoryCache) startJanitor() {
+	ticker := time.NewTicker(c.cleanup)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.evictExpired()
+		case <-c.stop:
+			return
+		}
+	}
+}
+
+func (c *InMemoryCache) evictExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now().UnixNano()
+	for k, item := range c.items {
+		if item.expiration > 0 && now > item.expiration {
+			delete(c.items, k)
+		}
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+var _ Cache = (*InMemoryCache)(nil)
+
 // Cache defines the caching operations required.
 type Cache interface {
 	Set(key string, val interface{}, ttl time.Duration)
@@ -27,10 +29,11 @@ func (item *cacheItem) expired() bool {
 
 // InMemoryCache provides a thread-safe, TTL-based caching layer.
 type InMemoryCache struct {
-	mu      sync.RWMutex
-	items   map[string]cacheItem
-	cleanup time.Duration
-	stop    chan struct{}
+	mu        sync.RWMutex
+	items     map[string]cacheItem
+	cleanup   time.Duration
+	stop      chan struct{}
+	closeOnce sync.Once
 }
 
 // NewInMemoryCache instantiates a thread-safe memory cache.
@@ -47,7 +50,7 @@ func NewInMemoryCache(cleanupInterval time.Duration) *InMemoryCache {
 	return c
 }
 
-// Set stores a value inside the cache with a specified TTL.
+// Set stores a value under key with the given TTL. A ttl of zero or less stores the item with no expiration.
 func (c *InMemoryCache) Set(key string, val interface{}, ttl time.Duration) {
 	var exp int64
 	if ttl > 0 {
@@ -88,11 +91,9 @@ func (c *InMemoryCache) Delete(key string) {
 	delete(c.items, key)
 }
 
-// Close shuts down the janitor cleanup goroutine.
+// Close signals the background janitor to stop. Safe to call multiple times.
 func (c *InMemoryCache) Close() {
-	if c.stop != nil {
-		close(c.stop)
-	}
+	c.closeOnce.Do(func() { close(c.stop) })
 }
 
 func (c *InMemoryCache) startJanitor() {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -55,4 +57,29 @@ func TestInMemoryCache_Delete(t *testing.T) {
 	if found {
 		t.Fatal("expected foo to be deleted")
 	}
+}
+
+func TestInMemoryCache_ConcurrentAccess(t *testing.T) {
+	c := NewInMemoryCache(0)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			c.Set(fmt.Sprintf("k%d", i), i, time.Minute)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			c.Get(fmt.Sprintf("k%d", i))
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestInMemoryCache_CloseIdempotent(t *testing.T) {
+	c := NewInMemoryCache(10 * time.Millisecond)
+	c.Close()
+	c.Close() // must not panic
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,58 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInMemoryCache_GetSet(t *testing.T) {
+	c := NewInMemoryCache(10 * time.Millisecond)
+	defer c.Close()
+
+	// Set & Get before expiration
+	c.Set("foo", "bar", 50*time.Millisecond)
+	val, found := c.Get("foo")
+	if !found {
+		t.Fatal("expected to find foo")
+	}
+	if val.(string) != "bar" {
+		t.Fatalf("expected bar, got %v", val)
+	}
+
+	// Wait for expiration
+	time.Sleep(60 * time.Millisecond)
+	_, found = c.Get("foo")
+	if found {
+		t.Fatal("expected foo to be expired and not found")
+	}
+}
+
+func TestInMemoryCache_Eviction(t *testing.T) {
+	c := NewInMemoryCache(10 * time.Millisecond)
+	defer c.Close()
+
+	c.Set("short-lived", "data", 15*time.Millisecond)
+
+	// Wait enough for cleaner goroutine to run
+	time.Sleep(30 * time.Millisecond)
+
+	// Since we sleep longer than TTL + clean interval, internal map should not leak the entry.
+	// We can check if Get returns found=false.
+	_, found := c.Get("short-lived")
+	if found {
+		t.Fatal("expected item to be evicted")
+	}
+}
+
+func TestInMemoryCache_Delete(t *testing.T) {
+	c := NewInMemoryCache(10 * time.Millisecond)
+	defer c.Close()
+
+	c.Set("foo", "bar", 10*time.Minute)
+	c.Delete("foo")
+
+	_, found := c.Get("foo")
+	if found {
+		t.Fatal("expected foo to be deleted")
+	}
+}

--- a/internal/proxy/cache_transport.go
+++ b/internal/proxy/cache_transport.go
@@ -1,0 +1,108 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/kadragon/apis-data-spcdeinfoservice-cloud-run/internal/cache"
+)
+
+type cachedResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+// CachingRoundTripper intercepts HTTP requests and caches HTTP 200 OK responses.
+type CachingRoundTripper struct {
+	underlying http.RoundTripper
+	cache      cache.Cache
+	ttl        time.Duration
+}
+
+// NewCachingRoundTripper wraps an existing RoundTripper with cache support.
+func NewCachingRoundTripper(underlying http.RoundTripper, c cache.Cache, ttl time.Duration) *CachingRoundTripper {
+	return &CachingRoundTripper{
+		underlying: underlying,
+		cache:      c,
+		ttl:        ttl,
+	}
+}
+
+// RoundTrip executes the HTTP request, returning cached response if present, otherwise fetching and caching.
+func (c *CachingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Only cache GET requests
+	if req.Method != http.MethodGet {
+		return c.underlying.RoundTrip(req)
+	}
+
+	key := generateCacheKey(req.Method, req.URL)
+	if val, found := c.cache.Get(key); found {
+		if cached, ok := val.(*cachedResponse); ok {
+			// Restore response from cache
+			resp := &http.Response{
+				StatusCode:    cached.StatusCode,
+				Proto:         "HTTP/1.1",
+				ProtoMajor:    1,
+				ProtoMinor:    1,
+				Header:        cloneHeader(cached.Header),
+				Body:          io.NopCloser(bytes.NewReader(cached.Body)),
+				ContentLength: int64(len(cached.Body)),
+				Request:       req,
+			}
+			return resp, nil
+		}
+	}
+
+	// Cache Miss: execute upstream call
+	resp, err := c.underlying.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only cache HTTP 200 OK responses
+	if resp.StatusCode == http.StatusOK {
+		bodyBytes, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		cached := &cachedResponse{
+			StatusCode: resp.StatusCode,
+			Header:     cloneHeader(resp.Header),
+			Body:       bodyBytes,
+		}
+		c.cache.Set(key, cached, c.ttl)
+
+		// Re-populate response body for current consumer
+		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	return resp, nil
+}
+
+func generateCacheKey(method string, u *url.URL) string {
+	q := u.Query()
+	q.Del("serviceKey")        // Strip sensitive service API key
+	encodedQuery := q.Encode() // Note: Encode() natively sorts parameters by key
+
+	base := u.Scheme + "://" + u.Host + u.Path
+	if encodedQuery != "" {
+		base += "?" + encodedQuery
+	}
+	return method + ":" + base
+}
+
+func cloneHeader(h http.Header) http.Header {
+	h2 := make(http.Header, len(h))
+	for k, vv := range h {
+		vv2 := make([]string, len(vv))
+		copy(vv2, vv)
+		h2[k] = vv2
+	}
+	return h2
+}

--- a/internal/proxy/cache_transport.go
+++ b/internal/proxy/cache_transport.go
@@ -3,12 +3,15 @@ package proxy
 import (
 	"bytes"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/kadragon/apis-data-spcdeinfoservice-cloud-run/internal/cache"
 )
+
+var _ http.RoundTripper = (*CachingRoundTripper)(nil)
 
 type cachedResponse struct {
 	StatusCode int
@@ -42,7 +45,6 @@ func (c *CachingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	key := generateCacheKey(req.Method, req.URL)
 	if val, found := c.cache.Get(key); found {
 		if cached, ok := val.(*cachedResponse); ok {
-			// Restore response from cache
 			resp := &http.Response{
 				StatusCode:    cached.StatusCode,
 				Proto:         "HTTP/1.1",
@@ -57,7 +59,6 @@ func (c *CachingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		}
 	}
 
-	// Cache Miss: execute upstream call
 	resp, err := c.underlying.RoundTrip(req)
 	if err != nil {
 		return nil, err
@@ -77,8 +78,10 @@ func (c *CachingRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			Body:       bodyBytes,
 		}
 		c.cache.Set(key, cached, c.ttl)
+		// Note: data.go.kr may return HTTP 200 with an error body (e.g. resultCode != "00").
+		// This proxy does not inspect response bodies, so such errors are cached for the full TTL.
+		log.Printf("cache: stored key=%q ttl=%s", key, c.ttl)
 
-		// Re-populate response body for current consumer
 		resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	}
 

--- a/internal/proxy/cache_transport_test.go
+++ b/internal/proxy/cache_transport_test.go
@@ -1,0 +1,152 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kadragon/apis-data-spcdeinfoservice-cloud-run/internal/cache"
+)
+
+type mockRoundTripper struct {
+	calls atomic.Int32
+	fn    func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.calls.Add(1)
+	return m.fn(req)
+}
+
+func TestCachingRoundTripper_HitAndMiss(t *testing.T) {
+	memCache := cache.NewInMemoryCache(10 * time.Minute)
+	defer memCache.Close()
+
+	// Mock upstream that returns a counter
+	var upstreamCalls int32
+	mockUpstream := func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&upstreamCalls, 1)
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader([]byte("response-body"))),
+			Request:    req,
+		}
+		resp.Header.Set("Content-Type", "application/xml")
+		return resp, nil
+	}
+
+	transport := NewCachingRoundTripper(
+		&mockRoundTripper{fn: mockUpstream},
+		memCache,
+		50*time.Millisecond,
+	)
+
+	// 1. First Request (Miss)
+	req1, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com/test?serviceKey=secret123&a=1&b=2", nil)
+	resp1, err := transport.RoundTrip(req1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+
+	if string(body1) != "response-body" {
+		t.Fatalf("want response-body, got %s", body1)
+	}
+	if resp1.Header.Get("Content-Type") != "application/xml" {
+		t.Fatalf("want application/xml, got %s", resp1.Header.Get("Content-Type"))
+	}
+	if atomic.LoadInt32(&upstreamCalls) != 1 {
+		t.Fatalf("expected 1 upstream call, got %d", atomic.LoadInt32(&upstreamCalls))
+	}
+
+	// 2. Second Request (Hit) - serviceKey is different, param order is different, but should hit
+	req2, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com/test?b=2&serviceKey=diffkey&a=1", nil)
+	resp2, err := transport.RoundTrip(req2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if string(body2) != "response-body" {
+		t.Fatalf("want cached response-body, got %s", body2)
+	}
+	if resp2.Header.Get("Content-Type") != "application/xml" {
+		t.Fatalf("want application/xml, got %s", resp2.Header.Get("Content-Type"))
+	}
+	// Upstream calls should still be 1 (Cache Hit!)
+	if atomic.LoadInt32(&upstreamCalls) != 1 {
+		t.Fatalf("expected cached hit to skip upstream call, but count is %d", atomic.LoadInt32(&upstreamCalls))
+	}
+
+	// 3. Expire cache
+	time.Sleep(60 * time.Millisecond)
+
+	req3, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com/test?a=1&b=2", nil)
+	resp3, err := transport.RoundTrip(req3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp3.Body.Close()
+
+	// Upstream call should be 2 (Cache Miss after expiration)
+	if atomic.LoadInt32(&upstreamCalls) != 2 {
+		t.Fatalf("expected upstream call after expiration, but count is %d", atomic.LoadInt32(&upstreamCalls))
+	}
+}
+
+func TestCachingRoundTripper_Non200NoCache(t *testing.T) {
+	memCache := cache.NewInMemoryCache(10 * time.Minute)
+	defer memCache.Close()
+
+	var upstreamCalls int32
+	mockUpstream := func(req *http.Request) (*http.Response, error) {
+		atomic.AddInt32(&upstreamCalls, 1)
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(bytes.NewReader([]byte("error"))),
+			Request:    req,
+		}, nil
+	}
+
+	transport := NewCachingRoundTripper(
+		&mockRoundTripper{fn: mockUpstream},
+		memCache,
+		10*time.Minute,
+	)
+
+	req1, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com/test", nil)
+	resp1, _ := transport.RoundTrip(req1)
+	resp1.Body.Close()
+
+	req2, _ := http.NewRequestWithContext(context.Background(), "GET", "http://example.com/test", nil)
+	resp2, _ := transport.RoundTrip(req2)
+	resp2.Body.Close()
+
+	if atomic.LoadInt32(&upstreamCalls) != 2 {
+		t.Fatalf("5xx response should not be cached, got %d calls", atomic.LoadInt32(&upstreamCalls))
+	}
+}
+
+func TestGenerateCacheKey_Sanitization(t *testing.T) {
+	u, _ := url.Parse("http://apis.data.go.kr/test?serviceKey=abc%3D%3D&a=2&b=1")
+	key := generateCacheKey("GET", u)
+	expected := "GET:http://apis.data.go.kr/test?a=2&b=1"
+	if key != expected {
+		t.Fatalf("expected cache key %q, got %q", expected, key)
+	}
+
+	u2, _ := url.Parse("http://apis.data.go.kr/test?b=1&a=2&serviceKey=XYZ")
+	key2 := generateCacheKey("GET", u2)
+	if key2 != expected {
+		t.Fatalf("expected sorted cache key to match: got %q", key2)
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -28,16 +28,25 @@ func NewClient() *http.Client {
 
 	var rt http.RoundTripper = transport
 
-	if os.Getenv("CACHE_ENABLED") == "true" {
+	cacheEnabled := os.Getenv("CACHE_ENABLED")
+	if cacheEnabled != "" && cacheEnabled != "true" {
+		log.Printf("cache: CACHE_ENABLED=%q not recognized; use \"true\" to enable", cacheEnabled)
+	}
+	if cacheEnabled == "true" {
 		ttlMin := 10
 		if ttlStr := os.Getenv("CACHE_TTL_MINUTES"); ttlStr != "" {
-			if val, err := strconv.Atoi(ttlStr); err == nil && val > 0 {
+			if val, err := strconv.Atoi(ttlStr); err != nil {
+				log.Printf("cache: CACHE_TTL_MINUTES=%q is not a valid integer, using default %d min", ttlStr, ttlMin)
+			} else if val <= 0 {
+				log.Printf("cache: CACHE_TTL_MINUTES=%d must be positive, using default %d min", val, ttlMin)
+			} else {
 				ttlMin = val
 			}
 		}
 		ttl := time.Duration(ttlMin) * time.Minute
 		memCache := cache.NewInMemoryCache(1 * time.Minute)
 		rt = NewCachingRoundTripper(transport, memCache, ttl)
+		log.Printf("cache: enabled, ttl=%s", ttl)
 	}
 
 	return &http.Client{

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -6,9 +6,12 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/kadragon/apis-data-spcdeinfoservice-cloud-run/internal/cache"
 )
 
 // HeaderTimeout bounds time to receive response headers per attempt.
@@ -16,14 +19,30 @@ import (
 var HeaderTimeout = 10 * time.Second
 
 func NewClient() *http.Client {
+	transport := &http.Transport{
+		MaxIdleConns:          200,
+		MaxIdleConnsPerHost:   200,
+		IdleConnTimeout:       90 * time.Second,
+		ResponseHeaderTimeout: HeaderTimeout,
+	}
+
+	var rt http.RoundTripper = transport
+
+	if os.Getenv("CACHE_ENABLED") == "true" {
+		ttlMin := 10
+		if ttlStr := os.Getenv("CACHE_TTL_MINUTES"); ttlStr != "" {
+			if val, err := strconv.Atoi(ttlStr); err == nil && val > 0 {
+				ttlMin = val
+			}
+		}
+		ttl := time.Duration(ttlMin) * time.Minute
+		memCache := cache.NewInMemoryCache(1 * time.Minute)
+		rt = NewCachingRoundTripper(transport, memCache, ttl)
+	}
+
 	return &http.Client{
-		Timeout: 0,
-		Transport: &http.Transport{
-			MaxIdleConns:          200,
-			MaxIdleConnsPerHost:   200,
-			IdleConnTimeout:       90 * time.Second,
-			ResponseHeaderTimeout: HeaderTimeout,
-		},
+		Timeout:   0,
+		Transport: rt,
 	}
 }
 

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -112,8 +112,8 @@ func TestHandler_5xxRetryExhaustion(t *testing.T) {
 	if rec.Code != http.StatusBadGateway {
 		t.Fatalf("want 502, got %d", rec.Code)
 	}
-	if calls.Load() != 3 {
-		t.Fatalf("want 3 upstream calls, got %d", calls.Load())
+	if calls.Load() != 2 {
+		t.Fatalf("want 2 upstream calls, got %d", calls.Load())
 	}
 	if rec.Header().Get("Access-Control-Allow-Origin") != "*" {
 		t.Fatal("missing CORS on error response")

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	MaxRetries    = 2
+	MaxRetries    = 1
 	BackoffBaseMs = 1000
 )
 

--- a/internal/proxy/retry_test.go
+++ b/internal/proxy/retry_test.go
@@ -45,8 +45,8 @@ func TestFetchWithRetry_5xxExhausted(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if calls.Load() != 3 {
-		t.Fatalf("want 3 attempts, got %d", calls.Load())
+	if calls.Load() != 2 {
+		t.Fatalf("want 2 attempts, got %d", calls.Load())
 	}
 	var ue *UpstreamError
 	if !errors.As(err, &ue) {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,3 +12,6 @@ pre-commit:
     - name: build
       glob: "*.go"
       run: go build ./...
+
+    - name: sweep
+      run: ./tools/sweep.sh

--- a/tools/sweep.sh
+++ b/tools/sweep.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -euo pipefail
+
+# Project root path detection
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+echo "=== Running Harness & Convention Sweep Checks ==="
+
+FAILED=0
+
+# 1. Golden Principle 1: Service keys never in logs
+# Verify no direct logging of serviceKey, authKey, DATAGOKR_SERVICEKEY, AUTH_API_KEY
+# Ensure gin.Default() or gin.Logger() (which leak path parameters including service keys) are not used
+echo "Checking for sensitive key leak in logs..."
+if grep -rnE 'log\.(Print|Fatal|Panic)[a-zA-Z]*\(.*(serviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY).*\)' cmd/ internal/ > /dev/null 2>&1; then
+  echo "❌ Error: Code contains direct logging of sensitive keys."
+  grep -rnE 'log\.(Print|Fatal|Panic)[a-zA-Z]*\(.*(serviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY).*\)' cmd/ internal/ || true
+  FAILED=1
+fi
+
+if grep -rn 'gin.Default()' cmd/ > /dev/null 2>&1; then
+  echo "❌ Error: Do not use gin.Default() because it includes the default logger which logs raw query parameters (and leaks DATAGOKR_SERVICEKEY). Use gin.New() instead."
+  grep -rn 'gin.Default()' cmd/ || true
+  FAILED=1
+fi
+
+if grep -rn 'gin.Logger()' cmd/ > /dev/null 2>&1; then
+  echo "❌ Error: Do not use gin.Logger() which logs raw query parameters. Use gin.New() and custom recovery middleware without default logging."
+  grep -rn 'gin.Logger()' cmd/ || true
+  FAILED=1
+fi
+
+# 2. Golden Principle 2: Auth middleware on all non-health routes
+# Check that proxy.AuthMiddleware is reference in cmd/server/main.go
+echo "Checking for AuthMiddleware registration..."
+if ! grep -q 'proxy.AuthMiddleware' cmd/server/main.go; then
+  echo "❌ Error: AuthMiddleware registration missing in cmd/server/main.go"
+  FAILED=1
+fi
+
+# 3. Golden Principle 3: New service API = new file (One ServiceSpec per file)
+echo "Checking service specs convention..."
+for file in internal/services/*.go; do
+  filename=$(basename "$file")
+  if [ "$filename" = "registry.go" ] || [ "$filename" = "registry_test.go" ]; then
+    continue
+  fi
+  count=$(grep -c "ServiceSpec{" "$file" || true)
+  if [ "$count" -ne 1 ]; then
+    echo "❌ Error: $file must contain exactly one ServiceSpec definition, found $count"
+    FAILED=1
+  fi
+done
+
+# 4. AGENTS.md Size check (target <= 100 lines, hard warn > 200)
+echo "Checking AGENTS.md size limit..."
+if [ -f "AGENTS.md" ]; then
+  lines=$(wc -l < AGENTS.md | xargs)
+  if [ "$lines" -gt 200 ]; then
+    echo "❌ Error: AGENTS.md exceeds the hard size budget of 200 lines (current: $lines lines)"
+    FAILED=1
+  fi
+else
+  echo "❌ Error: Missing AGENTS.md"
+  FAILED=1
+fi
+
+# 5. Check if required documentation exists
+echo "Checking required documentation docs/*.md..."
+docs=("architecture.md" "conventions.md" "delegation.md" "eval-criteria.md" "runbook.md" "workflows.md")
+for doc in "${docs[@]}"; do
+  if [ ! -f "docs/$doc" ]; then
+    echo "❌ Error: Missing required documentation docs/$doc"
+    FAILED=1
+  fi
+done
+
+# 6. Go Formatting check
+echo "Checking Go formatting..."
+fmt_output=$(gofmt -l cmd/ internal/ || true)
+if [ -n "$fmt_output" ]; then
+  echo "❌ Error: The following files are not formatted with gofmt:"
+  echo "$fmt_output"
+  FAILED=1
+fi
+
+# 7. Check if tests pass and compile
+echo "Running project tests..."
+if ! go test ./... > /dev/null 2>&1; then
+  echo "❌ Error: Tests are failing or code does not compile."
+  FAILED=1
+fi
+
+if [ $FAILED -ne 0 ]; then
+  echo "=== Sweep Failed! ==="
+  exit 1
+else
+  echo "✅ Sweep passed successfully!"
+  exit 0
+fi

--- a/tools/sweep.sh
+++ b/tools/sweep.sh
@@ -32,7 +32,7 @@ if grep -rn 'gin.Logger()' cmd/ > /dev/null 2>&1; then
 fi
 
 # 2. Golden Principle 2: Auth middleware on all non-health routes
-# Check that proxy.AuthMiddleware is reference in cmd/server/main.go
+# Check that proxy.AuthMiddleware string appears in cmd/server/main.go (string-presence only; does not verify route scope)
 echo "Checking for AuthMiddleware registration..."
 if ! grep -q 'proxy.AuthMiddleware' cmd/server/main.go; then
   echo "❌ Error: AuthMiddleware registration missing in cmd/server/main.go"


### PR DESCRIPTION
## Summary

- Add in-memory caching layer for upstream proxy responses
- Fix retry budget to align with Cloud Run 60s timeout
- Add `tools/sweep.sh` for automated convention checks

## Test plan

- [ ] Verify cached responses served on repeated requests
- [ ] Confirm retry logic does not exceed Cloud Run timeout
- [ ] Run `tools/sweep.sh` and confirm no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)