### PR TITLE
[HARNESS] gitignore machine-local .claude/ and cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Tool configs (machine-local)
 .antigravitycli/
+.claude/
+cache/


### PR DESCRIPTION
Ignore machine-local runtime artifacts (`.claude/` Claude Code state, `cache/` agy/codex review cache) so they don't show as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)