### PR TITLE
[FIX] context-aware error handling in proxyTarget

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -14,6 +14,10 @@ import (
 	"github.com/kadragon/apis-data-spcdeinfoservice-cloud-run/internal/cache"
 )
 
+// StatusClientClosedRequest mirrors nginx's 499: the client went away before
+// the upstream response was ready, so any response body we write is moot.
+const StatusClientClosedRequest = 499
+
 // HeaderTimeout bounds time to receive response headers per attempt.
 // Body streaming is not subject to this deadline. Var so tests can override.
 var HeaderTimeout = 10 * time.Second
@@ -71,6 +75,7 @@ func NewHandler(baseURL, upstreamPath, serviceKey string, client *http.Client) g
 func proxyTarget(c *gin.Context, client *http.Client, target string) {
 	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, target, nil)
 	if err != nil {
+		slog.Error("build upstream request", "err", scrubServiceKey(err), "target", redactURL(target))
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{
 			"error":   "Internal Server Error",
 			"message": "Failed to build upstream request",
@@ -81,6 +86,22 @@ func proxyTarget(c *gin.Context, client *http.Client, target string) {
 
 	resp, err := fetchWithRetry(c.Request.Context(), client, req)
 	if err != nil {
+		// fetchWithRetry returns the raw context error when the parent context
+		// ends during backoff. Map those explicitly instead of a generic 502.
+		if errors.Is(err, context.Canceled) {
+			c.AbortWithStatusJSON(StatusClientClosedRequest, gin.H{
+				"error":   "Client Closed Request",
+				"message": "Request canceled by client",
+			})
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			c.AbortWithStatusJSON(http.StatusGatewayTimeout, gin.H{
+				"error":   "Gateway Timeout",
+				"message": "Request timed out",
+			})
+			return
+		}
 		var ue *UpstreamError
 		if errors.As(err, &ue) {
 			errTitle := "Bad Gateway"
@@ -111,7 +132,8 @@ func proxyTarget(c *gin.Context, client *http.Client, target string) {
 	c.Header("Content-Type", ct)
 	c.Status(resp.StatusCode)
 
-	if _, err := io.Copy(c.Writer, resp.Body); err != nil && !errors.Is(err, context.Canceled) {
+	if _, err := io.Copy(c.Writer, resp.Body); err != nil &&
+		!errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		slog.Warn("pipe error", "err", err)
 	}
 }

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -197,6 +197,41 @@ func TestHandler_ContextCanceledDuringRetry_Returns499(t *testing.T) {
 	}
 }
 
+func TestHandler_ContextCanceledDuringFinalRetryDo_Returns499(t *testing.T) {
+	old := BackoffBaseMs
+	BackoffBaseMs = 0
+	t.Cleanup(func() { BackoffBaseMs = old })
+
+	var callCount atomic.Int32
+	secondCallStarted := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		close(secondCallStarted)
+		<-r.Context().Done()
+	}))
+	defer upstream.Close()
+
+	r := newHandlerEngine(upstream)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, "GET", "/svc/getThing", nil)
+	rec := httptest.NewRecorder()
+
+	go func() {
+		<-secondCallStarted
+		cancel()
+	}()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != StatusClientClosedRequest {
+		t.Fatalf("want 499 on cancel during final retry client.Do, got %d", rec.Code)
+	}
+}
+
 func TestProxyTarget_RequestBuildFailureLogsRedacted(t *testing.T) {
 	var buf bytes.Buffer
 	prev := slog.Default()

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1,12 +1,16 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -144,6 +148,79 @@ func TestHandler_5xxThenSuccess(t *testing.T) {
 	}
 	if calls.Load() != 2 {
 		t.Fatalf("want 2 upstream calls, got %d", calls.Load())
+	}
+}
+
+func TestHandler_ContextTimeoutDuringRetry_Returns504(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // 503 forces a retry + backoff
+	}))
+	defer upstream.Close()
+
+	r := newHandlerEngine(upstream)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, "GET", "/svc/getThing", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("want 504 on context deadline, got %d", rec.Code)
+	}
+}
+
+func TestHandler_ContextCanceledDuringRetry_Returns499(t *testing.T) {
+	var once sync.Once
+	firstHit := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		once.Do(func() { close(firstHit) })
+	}))
+	defer upstream.Close()
+
+	r := newHandlerEngine(upstream)
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequestWithContext(ctx, "GET", "/svc/getThing", nil)
+	rec := httptest.NewRecorder()
+
+	go func() {
+		<-firstHit
+		// Let client.Do return so the cancel lands inside the ~1s backoff
+		// window rather than during the in-flight request.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != StatusClientClosedRequest {
+		t.Fatalf("want 499 on client cancel, got %d", rec.Code)
+	}
+}
+
+func TestProxyTarget_RequestBuildFailureLogsRedacted(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	defer slog.SetDefault(prev)
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequestWithContext(context.Background(), "GET", "/svc/getThing", nil)
+
+	// An ASCII control char makes http.NewRequestWithContext fail to parse.
+	badTarget := "http://example.com/path\x7f?serviceKey=SECRET123"
+	proxyTarget(c, handlerTestClient, badTarget)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", rec.Code)
+	}
+	logOut := buf.String()
+	if logOut == "" {
+		t.Fatal("expected an error log on request build failure")
+	}
+	if strings.Contains(logOut, "SECRET123") {
+		t.Fatalf("serviceKey leaked into log: %s", logOut)
 	}
 }
 

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -11,10 +11,10 @@ import (
 	"time"
 )
 
-const (
-	MaxRetries    = 1
-	BackoffBaseMs = 1000
-)
+const MaxRetries = 1
+
+// BackoffBaseMs is a var so tests can override it without timing flakiness.
+var BackoffBaseMs = 1000
 
 type UpstreamError struct {
 	Message    string
@@ -37,6 +37,9 @@ func fetchWithRetry(parent context.Context, client *http.Client, baseReq *http.R
 		resp, err := client.Do(req)
 		switch {
 		case err != nil:
+			if parent.Err() != nil {
+				return nil, parent.Err()
+			}
 			isTimeout := isTimeoutErr(err)
 			msg := scrubServiceKey(err)
 			if isTimeout {

--- a/tools/sweep.sh
+++ b/tools/sweep.sh
@@ -14,10 +14,12 @@ FAILED=0
 # Ensure gin.Default() or gin.Logger() (which leak path parameters including service keys) are not used
 echo "Checking for sensitive key leak in logs..."
 if grep -rnE '(log|slog)\.(Print|Fatal|Panic|Info|Warn|Error|Debug)[a-zA-Z]*\(.*([sS]erviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY).*\)' cmd/ internal/ \
-     | grep -qvE 'scrub[A-Za-z]*Key\s*\(|redact[A-Za-z]+\s*\('; then
+     | perl -pe 's/\b(?:scrub[A-Za-z]*Key|redact[A-Za-z]+)\s*\([^)]*\)//g' \
+     | grep -qE '([sS]erviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY)'; then
   echo "❌ Error: Code contains direct logging of sensitive keys."
   grep -rnE '(log|slog)\.(Print|Fatal|Panic|Info|Warn|Error|Debug)[a-zA-Z]*\(.*([sS]erviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY).*\)' cmd/ internal/ \
-    | grep -vE 'scrub[A-Za-z]*Key\s*\(|redact[A-Za-z]+\s*\(' || true
+    | perl -pe 's/\b(?:scrub[A-Za-z]*Key|redact[A-Za-z]+)\s*\([^)]*\)//g' \
+    | grep -E '([sS]erviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY)' || true
   FAILED=1
 fi
 

--- a/tools/sweep.sh
+++ b/tools/sweep.sh
@@ -13,9 +13,11 @@ FAILED=0
 # Verify no direct logging of serviceKey, authKey, DATAGOKR_SERVICEKEY, AUTH_API_KEY
 # Ensure gin.Default() or gin.Logger() (which leak path parameters including service keys) are not used
 echo "Checking for sensitive key leak in logs..."
-if grep -rnE '(log|slog)\.(Print|Fatal|Panic|Info|Warn|Error|Debug)[a-zA-Z]*\(.*([sS]erviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY).*\)' cmd/ internal/ > /dev/null 2>&1; then
+if grep -rnE '(log|slog)\.(Print|Fatal|Panic|Info|Warn|Error|Debug)[a-zA-Z]*\(.*([sS]erviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY).*\)' cmd/ internal/ \
+     | grep -qvE 'scrub[A-Za-z]*Key\s*\(|redact[A-Za-z]+\s*\('; then
   echo "❌ Error: Code contains direct logging of sensitive keys."
-  grep -rnE '(log|slog)\.(Print|Fatal|Panic|Info|Warn|Error|Debug)[a-zA-Z]*\(.*([sS]erviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY).*\)' cmd/ internal/ || true
+  grep -rnE '(log|slog)\.(Print|Fatal|Panic|Info|Warn|Error|Debug)[a-zA-Z]*\(.*([sS]erviceKey|authKey|DATAGOKR_SERVICEKEY|AUTH_API_KEY).*\)' cmd/ internal/ \
+    | grep -vE 'scrub[A-Za-z]*Key\s*\(|redact[A-Za-z]+\s*\(' || true
   FAILED=1
 fi
 


### PR DESCRIPTION
- Map context.Canceled → 499 (client closed request)
- Map context.DeadlineExceeded → 504 (gateway timeout)
- Log structured error on request build failure with redacted URL
- Suppress context.DeadlineExceeded in io.Copy pipe error check
- Fix sweep false positive: exclude scrub/redact fn names from key-leak regex
- Add tests: 504 on timeout, 499 on cancel, log redaction on build failure